### PR TITLE
Using grant code as a unique grant identifier

### DIFF
--- a/api.http
+++ b/api.http
@@ -7,6 +7,7 @@ Content-Type: application/json
 
 {
   "name": "Grant 1",
+  "code": "adding-value-2",
   "endpoints": [{
     "name": "get-prices",
     "url": "https://httpbin.org/anything",
@@ -20,7 +21,7 @@ Content-Type: application/json
 
 ### Get a Grant
 # @name getGrant
-GET {{base}}/grants/{{createGrant.response.body.grantId}}
+GET {{base}}/grants/{{createGrant.response.body.code}}
 
 ### Get all Grants
 # @name getGrants
@@ -28,12 +29,12 @@ GET {{base}}/grants
 
 ### Invoke external GET endpoint
 # @name invokeEndpoint
-GET {{base}}/grants/{{createGrant.response.body.grantId}}/endpoints/get-prices/invoke
+GET {{base}}/grants/{{createGrant.response.body.code}}/endpoints/get-prices/invoke
 Content-Type: application/json
 
 ### Invoke external POST endpoint
 # @name invokeEndpoint
-POST {{base}}/grants/{{createGrant.response.body.grantId}}/endpoints/calc-totals/invoke
+POST {{base}}/grants/{{createGrant.response.body.code}}/endpoints/calc-totals/invoke
 Content-Type: application/json
 
 {

--- a/src/grants/grant-service.js
+++ b/src/grants/grant-service.js
@@ -16,26 +16,26 @@ export const grantService = {
     return grantRepository.findAll()
   },
 
-  async findById (grantId) {
-    Grant.validateId(grantId)
+  async findByCode (code) {
+    Grant.validateCode(code)
 
-    const grant = await grantRepository.findById(grantId)
+    const grant = await grantRepository.findByCode(code)
 
     if (grant === null) {
-      throw Boom.notFound(`Grant ${grantId} not found`)
+      throw Boom.notFound(`Grant with code "${code}" not found`)
     }
 
     return grant
   },
 
-  async invokeGetEndpoint ({ grantId, name }) {
-    Grant.validateId(grantId)
+  async invokeGetEndpoint ({ code, name }) {
+    Grant.validateCode(code)
     Grant.validateEndpointName(name)
 
-    const grant = await grantRepository.findById(grantId)
+    const grant = await grantRepository.findByCode(code)
 
     if (grant === null) {
-      throw Boom.notFound(`Grant ${grantId} not found`)
+      throw Boom.notFound(`Grant with code "${code}" not found`)
     }
 
     const endpoint = grant.endpoints.find(
@@ -44,26 +44,26 @@ export const grantService = {
 
     if (!endpoint) {
       throw Boom.badRequest(
-        `Grant ${grantId} has no GET endpoint named '${name}'`
+        `Grant with code "${code}" has no GET endpoint named "${name}"`
       )
     }
 
-    const response = await wreck.get(`${endpoint.url}?grantId=${grantId}`, {
+    const response = await wreck.get(`${endpoint.url}?code=${code}`, {
       json: true
     })
 
     return response.payload
   },
 
-  async invokePostEndpoint ({ grantId, name, payload }) {
-    Grant.validateId(grantId)
+  async invokePostEndpoint ({ code, name, payload }) {
+    Grant.validateCode(code)
     Grant.validateEndpointName(name)
     Grant.validateEndpointPayload(payload)
 
-    const grant = await grantRepository.findById(grantId)
+    const grant = await grantRepository.findByCode(code)
 
     if (grant === null) {
-      throw Boom.notFound(`Grant ${grantId} not found`)
+      throw Boom.notFound(`Grant with code "${code}" not found`)
     }
 
     const endpoint = grant.endpoints.find(
@@ -72,7 +72,7 @@ export const grantService = {
 
     if (!endpoint) {
       throw Boom.badRequest(
-        `Grant ${grantId} has no POST endpoint named '${name}'`
+        `Grant with code "${code}" has no POST endpoint named "${name}"`
       )
     }
 

--- a/src/grants/grant-service.test.js
+++ b/src/grants/grant-service.test.js
@@ -19,7 +19,7 @@ describe('grantService', () => {
       }
 
       mock.method(Grant, 'create', () => grant)
-      mock.method(grantRepository, 'add', async () => {})
+      mock.method(grantRepository, 'add', async () => { })
 
       const result = await grantService.create({
         name: 'test',
@@ -58,28 +58,28 @@ describe('grantService', () => {
     })
   })
 
-  describe('findById', () => {
+  describe('findByCode', () => {
     it('returns the grant from the repository', async ({ mock }) => {
       const grant = {
-        id: '1',
+        code: '1',
         name: 'test 1',
         endpoints: []
       }
 
-      mock.method(Grant, 'validateId', () => '1')
-      mock.method(grantRepository, 'findById', async () => grant)
+      mock.method(Grant, 'validateCode', () => '1')
+      mock.method(grantRepository, 'findByCode', async () => grant)
 
-      const result = await grantService.findById('1')
+      const result = await grantService.findByCode('1')
 
       assert.deepEqual(result, grant)
     })
 
     it('throws when the grant is not found', async ({ mock }) => {
-      mock.method(Grant, 'validateId', () => '1')
-      mock.method(grantRepository, 'findById', async () => null)
+      mock.method(Grant, 'validateCode', () => '1')
+      mock.method(grantRepository, 'findByCode', async () => null)
 
-      assert.rejects(grantService.findById('1'), {
-        message: 'Grant 1 not found'
+      assert.rejects(grantService.findByCode('1'), {
+        message: 'Grant with code "1" not found'
       })
     })
   })
@@ -96,9 +96,9 @@ describe('grantService', () => {
         }]
       }
 
-      mock.method(Grant, 'validateId', () => '1')
+      mock.method(Grant, 'validateCode', () => '1')
       mock.method(Grant, 'validateEndpointName', () => 'test')
-      mock.method(grantRepository, 'findById', async () => grant)
+      mock.method(grantRepository, 'findByCode', async () => grant)
 
       const response = {
         arbitrary: 'response'
@@ -109,27 +109,27 @@ describe('grantService', () => {
       }))
 
       const result = await grantService.invokeGetEndpoint({
-        grantId: '1',
+        code: '1',
         name: 'test'
       })
 
-      assert.calledOnceWith(wreck.get, 'http://localhost?grantId=1', {
+      assert.calledOnceWith(wreck.get, 'http://localhost?code=1', {
         json: true
       })
       assert.deepEqual(result, response)
     })
 
     it('throws when the grant is not found', async ({ mock }) => {
-      mock.method(Grant, 'validateId', () => '1')
+      mock.method(Grant, 'validateCode', () => '1')
       mock.method(Grant, 'validateEndpointName', () => 'test')
-      mock.method(grantRepository, 'findById', async () => null)
-      mock.method(wreck, 'get', async () => {})
+      mock.method(grantRepository, 'findByCode', async () => null)
+      mock.method(wreck, 'get', async () => { })
 
       assert.rejects(grantService.invokeGetEndpoint({
-        grantId: '1',
+        code: '1',
         name: 'test'
       }), {
-        message: 'Grant 1 not found'
+        message: 'Grant with code "1" not found'
       })
 
       assert.notCalled(wreck.get)
@@ -142,16 +142,16 @@ describe('grantService', () => {
         endpoints: []
       }
 
-      mock.method(Grant, 'validateId', () => '1')
+      mock.method(Grant, 'validateCode', () => '1')
       mock.method(Grant, 'validateEndpointName', () => 'test')
-      mock.method(grantRepository, 'findById', async () => grant)
-      mock.method(wreck, 'get', async () => {})
+      mock.method(grantRepository, 'findByCode', async () => grant)
+      mock.method(wreck, 'get', async () => { })
 
       assert.rejects(grantService.invokeGetEndpoint({
-        grantId: '1',
+        code: '1',
         name: 'test'
       }), {
-        message: 'Grant 1 has no GET endpoint named \'test\''
+        message: 'Grant with code "1" has no GET endpoint named "test"'
       })
 
       assert.notCalled(wreck.get)
@@ -170,10 +170,10 @@ describe('grantService', () => {
         }]
       }
 
-      mock.method(Grant, 'validateId', () => '1')
+      mock.method(Grant, 'validateCode', () => '1')
       mock.method(Grant, 'validateEndpointName', () => 'test')
-      mock.method(Grant, 'validateEndpointPayload', () => ({ grantId: '1', name: 'test' }))
-      mock.method(grantRepository, 'findById', async () => grant)
+      mock.method(Grant, 'validateEndpointPayload', () => ({ code: '1', name: 'test' }))
+      mock.method(grantRepository, 'findByCode', async () => grant)
 
       const response = {
         arbitrary: 'response'
@@ -184,17 +184,17 @@ describe('grantService', () => {
       }))
 
       const result = await grantService.invokePostEndpoint({
-        grantId: '1',
+        code: '1',
         name: 'test',
         payload: {
-          grantId: '1',
+          code: '1',
           name: 'test'
         }
       })
 
       assert.calledOnceWith(wreck.post, 'http://localhost', {
         payload: {
-          grantId: '1',
+          code: '1',
           name: 'test'
         },
         json: true
@@ -204,21 +204,21 @@ describe('grantService', () => {
     })
 
     it('throws when the grant is not found', async ({ mock }) => {
-      mock.method(Grant, 'validateId', () => '1')
+      mock.method(Grant, 'validateCode', () => '1')
       mock.method(Grant, 'validateEndpointName', () => 'test')
-      mock.method(Grant, 'validateEndpointPayload', () => ({ grantId: '1', name: 'test' }))
-      mock.method(grantRepository, 'findById', async () => null)
-      mock.method(wreck, 'post', async () => {})
+      mock.method(Grant, 'validateEndpointPayload', () => ({ code: '1', name: 'test' }))
+      mock.method(grantRepository, 'findByCode', async () => null)
+      mock.method(wreck, 'post', async () => { })
 
       assert.rejects(grantService.invokePostEndpoint({
-        grantId: '1',
+        code: '1',
         name: 'test',
         payload: {
-          grantId: '1',
+          code: '1',
           name: 'test'
         }
       }), {
-        message: 'Grant 1 not found'
+        message: 'Grant with code "1" not found'
       })
 
       assert.notCalled(wreck.post)
@@ -231,21 +231,21 @@ describe('grantService', () => {
         endpoints: []
       }
 
-      mock.method(Grant, 'validateId', () => '1')
+      mock.method(Grant, 'validateCode', () => '1')
       mock.method(Grant, 'validateEndpointName', () => 'test')
-      mock.method(Grant, 'validateEndpointPayload', () => ({ grantId: '1', name: 'test' }))
-      mock.method(grantRepository, 'findById', async () => grant)
-      mock.method(wreck, 'post', async () => {})
+      mock.method(Grant, 'validateEndpointPayload', () => ({ code: '1', name: 'test' }))
+      mock.method(grantRepository, 'findByCode', async () => grant)
+      mock.method(wreck, 'post', async () => { })
 
       assert.rejects(grantService.invokePostEndpoint({
-        grantId: '1',
+        code: '1',
         name: 'test',
         payload: {
-          grantId: '1',
+          code: '1',
           name: 'test'
         }
       }), {
-        message: 'Grant 1 has no POST endpoint named \'test\''
+        message: 'Grant with code "1" has no POST endpoint named "test"'
       })
 
       assert.notCalled(wreck.post)
@@ -253,7 +253,7 @@ describe('grantService', () => {
 
     it('throws when the payload is invalid', async ({ mock }) => {
       const grant = {
-        id: '1',
+        code: '1',
         name: 'Test',
         endpoints: [{
           method: 'POST',
@@ -262,19 +262,19 @@ describe('grantService', () => {
         }]
       }
 
-      mock.method(Grant, 'validateId', () => '1')
+      mock.method(Grant, 'validateCode', () => '1')
       mock.method(Grant, 'validateEndpointName', () => 'test')
       mock.method(Grant, 'validateEndpointPayload', () => {
         throw new Error('Invalid request payload input')
       })
-      mock.method(grantRepository, 'findById', async () => grant)
-      mock.method(wreck, 'post', async () => {})
+      mock.method(grantRepository, 'findByCode', async () => grant)
+      mock.method(wreck, 'post', async () => { })
 
       assert.rejects(grantService.invokePostEndpoint({
-        grantId: '1',
+        code: '1',
         name: 'test',
         payload: {
-          grantId: '1'
+          code: '1'
         }
       }), {
         message: 'Invalid request payload input'

--- a/src/grants/grant.js
+++ b/src/grants/grant.js
@@ -1,6 +1,5 @@
 import Boom from '@hapi/boom'
 import Joi from 'joi'
-import { ObjectId } from 'mongodb'
 
 const endpointNameSchema = Joi.object({
   name: Joi.string().pattern(/^[a-z0-9-]+$/).min(1).max(30).required()
@@ -29,13 +28,16 @@ const endpointSchema = Joi.object({
     .required()
 })
 
-const idSchema = Joi.object({
-  grantId: Joi.string().hex().length(24)
+const codeSchema = Joi.object({
+  code: Joi.string().pattern(/^[a-z0-9-]+$/).min(1).max(500).required()
 })
 
-const createGrantSchema = Joi.object({
-  name: Joi.string().min(1).max(100).required()
-}).concat(endpointSchema)
+const createGrantSchema = Joi
+  .object({
+    name: Joi.string().min(1).max(500).required()
+  })
+  .concat(codeSchema)
+  .concat(endpointSchema)
 
 export const Grant = {
   create (props) {
@@ -46,7 +48,7 @@ export const Grant = {
     }
 
     return {
-      grantId: new ObjectId().toString(),
+      code: props.code,
       name: props.name,
       endpoints: props.endpoints.map(e => ({
         name: e.name,
@@ -56,12 +58,14 @@ export const Grant = {
     }
   },
 
-  validateId (grantId) {
-    const { error } = idSchema.validate({ grantId })
+  validateCode (code) {
+    const { error } = codeSchema.validate({ code })
 
     if (error) {
       throw Boom.badRequest(error)
     }
+
+    return code
   },
 
   validateEndpointName (name) {

--- a/src/grants/grant.test.js
+++ b/src/grants/grant.test.js
@@ -7,6 +7,7 @@ describe('grant', () => {
     it('creates a grant with valid properties', () => {
       const grant = Grant.create({
         name: 'test grant',
+        code: 'test-code',
         endpoints: [
           {
             name: 'endpoint1',
@@ -16,7 +17,7 @@ describe('grant', () => {
         ]
       })
 
-      assert.ok(grant.grantId)
+      assert.equal(grant.code, 'test-code')
       assert.equal(grant.name, 'test grant')
       assert.deepEqual(grant.endpoints, [{
         name: 'endpoint1',
@@ -28,6 +29,7 @@ describe('grant', () => {
     it('throws when properties invalid', () => {
       const props = {
         name: '',
+        code: '',
         endpoints: [{
           name: 'endpoint1',
           method: 'INVALID',
@@ -41,14 +43,14 @@ describe('grant', () => {
     })
   })
 
-  describe('validateId', () => {
-    it('parses a valid grantId', () => {
-      assert.doesNotThrow(() => Grant.validateId('507f1f77bcf86cd799439011'))
+  describe('validateCode', () => {
+    it('parses a valid code', () => {
+      assert.doesNotThrow(() => Grant.validateCode('test-code'))
     })
 
-    it('throws an error for an invalid grantId', () => {
-      assert.throws(() => Grant.validateId('invalid-id'), {
-        message: '"grantId" must only contain hexadecimal characters'
+    it('throws an error for an invalid code', () => {
+      assert.throws(() => Grant.validateCode(''), {
+        message: '"code" is not allowed to be empty'
       })
     })
   })

--- a/src/grants/index.js
+++ b/src/grants/index.js
@@ -14,7 +14,7 @@ export const grantsPlugin = {
 
         return h
           .response({
-            grantId: grant.grantId
+            code: grant.code
           })
           .code(201)
       }
@@ -27,7 +27,7 @@ export const grantsPlugin = {
         const grants = await grantService.findAll()
 
         return grants.map(grant => ({
-          grantId: grant.grantId,
+          code: grant.code,
           name: grant.name,
           endpoints: grant.endpoints
         }))
@@ -36,12 +36,12 @@ export const grantsPlugin = {
 
     server.route({
       method: 'GET',
-      path: '/grants/{grantId}',
+      path: '/grants/{code}',
       async handler (request, _h) {
-        const grant = await grantService.findById(request.params.grantId)
+        const grant = await grantService.findByCode(request.params.code)
 
         return {
-          grantId: grant.grantId,
+          code: grant.code,
           name: grant.name,
           endpoints: grant.endpoints
         }
@@ -50,10 +50,10 @@ export const grantsPlugin = {
 
     server.route({
       method: 'GET',
-      path: '/grants/{grantId}/endpoints/{name}/invoke',
+      path: '/grants/{code}/endpoints/{name}/invoke',
       async handler (request, _h) {
         const result = await grantService.invokeGetEndpoint({
-          grantId: request.params.grantId,
+          code: request.params.code,
           name: request.params.name
         })
 
@@ -63,10 +63,10 @@ export const grantsPlugin = {
 
     server.route({
       method: 'POST',
-      path: '/grants/{grantId}/endpoints/{name}/invoke',
+      path: '/grants/{code}/endpoints/{name}/invoke',
       async handler (request, _h) {
         const result = await grantService.invokePostEndpoint({
-          grantId: request.params.grantId,
+          code: request.params.code,
           name: request.params.name,
           payload: request.payload
         })

--- a/src/grants/index.test.js
+++ b/src/grants/index.test.js
@@ -16,7 +16,7 @@ describe('grantsPlugin', () => {
   describe('POST /grants', () => {
     it('creates a new grant and returns the id', async ({ mock }) => {
       mock.method(grantService, 'create', async props => ({
-        grantId: '1',
+        code: '1',
         ...props
       }))
 
@@ -37,7 +37,7 @@ describe('grantsPlugin', () => {
       assert.equal(statusCode, 201)
 
       assert.deepEqual(result, {
-        grantId: '1'
+        code: '1'
       })
     })
   })
@@ -46,13 +46,13 @@ describe('grantsPlugin', () => {
     it('returns all grants', async ({ mock }) => {
       mock.method(grantService, 'findAll', async () => [
         {
-          grantId: '1',
+          code: '1',
           name: 'test 1',
           endpoints: [],
           internal: 'this is private'
         },
         {
-          grantId: '2',
+          code: '2',
           name: 'test 2',
           endpoints: [],
           internal: 'this is private'
@@ -68,12 +68,12 @@ describe('grantsPlugin', () => {
 
       assert.deepEqual(result, [
         {
-          grantId: '1',
+          code: '1',
           name: 'test 1',
           endpoints: []
         },
         {
-          grantId: '2',
+          code: '2',
           name: 'test 2',
           endpoints: []
         }
@@ -81,10 +81,10 @@ describe('grantsPlugin', () => {
     })
   })
 
-  describe('GET /grants/{grantId}', () => {
+  describe('GET /grants/{code}', () => {
     it('returns matching grant', async ({ mock }) => {
-      mock.method(grantService, 'findById', async () => ({
-        grantId: '67c1d5d372de5936d94df74c',
+      mock.method(grantService, 'findByCode', async () => ({
+        code: 'adding-value',
         name: 'test 1',
         endpoints: [],
         internal: 'this is private'
@@ -92,20 +92,20 @@ describe('grantsPlugin', () => {
 
       const { statusCode, result } = await server.inject({
         method: 'GET',
-        url: '/grants/67c1d5d372de5936d94df74c'
+        url: '/grants/adding-value'
       })
 
       assert.equal(statusCode, 200)
 
       assert.deepEqual(result, {
-        grantId: '67c1d5d372de5936d94df74c',
+        code: 'adding-value',
         name: 'test 1',
         endpoints: []
       })
     })
   })
 
-  describe('GET /grants/{grantId}/endpoints/{name}/invoke', () => {
+  describe('GET /grants/{code}/endpoints/{name}/invoke', () => {
     it('returns response from endpoint', async ({ mock }) => {
       mock.method(grantService, 'invokeGetEndpoint', async () => ({
         arbitrary: 'result'
@@ -113,7 +113,7 @@ describe('grantsPlugin', () => {
 
       const { statusCode, result } = await server.inject({
         method: 'GET',
-        url: '/grants/67c1d5d372de5936d94df74c/endpoints/test/invoke'
+        url: '/grants/adding-value/endpoints/test/invoke'
       })
 
       assert.equal(statusCode, 200)
@@ -123,13 +123,13 @@ describe('grantsPlugin', () => {
       })
 
       assert.calledOnceWith(grantService.invokeGetEndpoint, {
-        grantId: '67c1d5d372de5936d94df74c',
+        code: 'adding-value',
         name: 'test'
       })
     })
   })
 
-  describe('POST /grants/{grantId}/endpoints/{name}/invoke', () => {
+  describe('POST /grants/{code}/endpoints/{name}/invoke', () => {
     it('returns response from endpoint', async ({ mock }) => {
       mock.method(grantService, 'invokePostEndpoint', async () => ({
         arbitrary: 'result'
@@ -137,9 +137,9 @@ describe('grantsPlugin', () => {
 
       const { statusCode, result } = await server.inject({
         method: 'POST',
-        url: '/grants/67c1d5d372de5936d94df74c/endpoints/test/invoke',
+        url: '/grants/adding-value/endpoints/test/invoke',
         payload: {
-          grantId: '67c1d5d372de5936d94df74c',
+          code: 'adding-value',
           name: 'test'
         }
       })
@@ -151,10 +151,10 @@ describe('grantsPlugin', () => {
       })
 
       assert.calledOnceWith(grantService.invokePostEndpoint, {
-        grantId: '67c1d5d372de5936d94df74c',
+        code: 'adding-value',
         name: 'test',
         payload: {
-          grantId: '67c1d5d372de5936d94df74c',
+          code: 'adding-value',
           name: 'test'
         }
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FUT-304

Work to index grants by `code` to be done separately https://eaflood.atlassian.net/browse/FUT-336. 