### PR TITLE
Fut 331 add traceid to response via headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ docker build --no-cache --tag fg-gas-backend .
 Run:
 
 ```bash
-docker run -e PORT=3001 -p 3001:3001 fg-gas-backend
+docker run -e PORT=3000 -p 3000:3000 fg-gas-backend
 ```
 
 ### Docker Compose

--- a/api.http
+++ b/api.http
@@ -1,4 +1,4 @@
-@base=http://localhost:3001
+@base=http://localhost:3000
 
 ### Create a Grant
 # @name createGrant

--- a/compose.yml
+++ b/compose.yml
@@ -12,14 +12,14 @@ services:
   gas:
     build: .
     ports:
-      - '3001:3001'
+      - '3000:3000'
     links:
       - 'mongodb:mongodb'
     depends_on:
       mongodb:
         condition: service_started
     environment:
-      PORT: 3001
+      PORT: 3000
       NODE_ENV: development
       MONGO_URI: mongodb://mongodb:27017/
     networks:

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "hapi-pulse": "^3.0.1",
         "mongodb": "^6.12.0",
         "pino": "^9.6.0",
-        "pino-pretty": "^13.0.0"
+        "pino-pretty": "^13.0.0",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "c8": "^10.1.3",
@@ -5393,6 +5394,19 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "hapi-pulse": "^3.0.1",
     "mongodb": "^6.12.0",
     "pino": "^9.6.0",
-    "pino-pretty": "^13.0.0"
+    "pino-pretty": "^13.0.0",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "c8": "^10.1.3",

--- a/src/server.js
+++ b/src/server.js
@@ -45,6 +45,16 @@ export const createServer = async () => {
     await mongoClient.close(true)
   })
 
+  server.ext('onPreResponse', (request, h) => {
+    const requestId = request.headers['x-cdp-request-id']
+
+    if (requestId && request.response.header) {
+      request.response.header('x-cdp-request-id', requestId)
+    }
+
+    return h.continue
+  })
+
   await server.register([
     {
       plugin: hapiPino,

--- a/src/server.js
+++ b/src/server.js
@@ -7,6 +7,7 @@ import { mongoClient } from './common/db.js'
 import { config } from './common/config.js'
 import { healthPlugin } from './health/index.js'
 import { grantsPlugin } from './grants/index.js'
+import { v4 as uuidv4 } from 'uuid'
 
 export const createServer = async () => {
   const server = hapi.server({
@@ -46,11 +47,13 @@ export const createServer = async () => {
   })
 
   server.ext('onPreResponse', (request, h) => {
-    const requestId = request.headers['x-cdp-request-id']
-
-    if (requestId && request.response.header) {
-      request.response.header('x-cdp-request-id', requestId)
+    if (!request.response.header) {
+      return h.continue
     }
+
+    const traceId = request.headers['x-cdp-request-id'] || uuidv4()
+
+    request.response.header('x-cdp-request-id', traceId)
 
     return h.continue
   })


### PR DESCRIPTION
Implementation is required to send a x-cdp-request-id header in the response. It can potentially come from the request which it will return the same value. After speaking to the maintainers of the hapi tracers they said it was ok to return a UUID. 