### PR TITLE
Local .http file client can switch envs

### DIFF
--- a/api.http
+++ b/api.http
@@ -1,5 +1,3 @@
-@base=http://localhost:3001
-
 ### Create a Grant
 # @name createGrant
 POST {{base}}/grants

--- a/http-client.env.json
+++ b/http-client.env.json
@@ -1,0 +1,17 @@
+{
+  "local": {
+    "base": "http://localhost:3000"
+  },
+  "dev": {
+    "base": "https://fg-gas-backend.dev.cdp-int.defra.cloud"
+  },
+  "test": {
+    "base": "https://fg-gas-backend.test.cdp-int.defra.cloud"
+  },
+  "perf test": {
+    "base": "https://fg-gas-backend.perf-test.cdp-int.defra.cloud"
+  },
+  "prod": {
+    "base": "https://fg-gas-backend.prod.cdp-int.defra.cloud"
+  }
+}


### PR DESCRIPTION
Allows to quickly test requests across envs without having to fish for env specific URLs.