### PR TITLE
Grant schema adjusted to match that in Jira

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Grant Application Service defines and manages farming grants and applications. I
   - [Development](#development)
   - [Testing](#testing)
   - [Production](#production)
-- [API endpoints](#api-endpoints)
 - [Docker](#docker)
   - [Production image](#production-image)
   - [Docker Compose](#docker-compose)
@@ -54,14 +53,6 @@ To test the application run:
 ```bash
 npm run test
 ```
-
-## API endpoints
-
-| Endpoint             | Description                    |
-| :------------------- | :----------------------------- |
-| `GET: /health`       | Health                         |
-| `GET: /example    `  | Example API (remove as needed) |
-| `GET: /example/<id>` | Example API (remove as needed) |
 
 ## Docker
 

--- a/api.http
+++ b/api.http
@@ -4,17 +4,24 @@ POST {{base}}/grants
 Content-Type: application/json
 
 {
-  "name": "Grant 1",
-  "code": "adding-value-2",
-  "endpoints": [{
-    "name": "get-prices",
-    "url": "https://httpbin.org/anything",
-    "method": "GET"
-  }, {
-    "name": "calc-totals",
-    "url": "https://httpbin.org/post",
-    "method": "POST"
-  }]
+  "code": "laying-hen-housing",
+  "metadata": {
+    "description": "Laying Hen Housing for Health and Welfare",
+    "startDate": "2026-01-01T00:00:00Z"
+  },
+  "actions": [
+    {
+      "name": "get-prices",
+      "url": "https://httpbin.org/anything",
+      "method": "GET"
+    },
+    {
+      "name": "calc-totals",
+      "url": "https://httpbin.org/post",
+      "method": "POST"
+    }
+  ],
+  "questions": []
 }
 
 ### Get a Grant
@@ -25,14 +32,14 @@ GET {{base}}/grants/{{createGrant.response.body.code}}
 # @name getGrants
 GET {{base}}/grants
 
-### Invoke external GET endpoint
-# @name invokeEndpoint
-GET {{base}}/grants/{{createGrant.response.body.code}}/endpoints/get-prices/invoke
+### Invoke external GET action
+# @name invokeGetAction
+GET {{base}}/grants/{{createGrant.response.body.code}}/actions/get-prices/invoke
 Content-Type: application/json
 
-### Invoke external POST endpoint
-# @name invokeEndpoint
-POST {{base}}/grants/{{createGrant.response.body.code}}/endpoints/calc-totals/invoke
+### Invoke external POST action
+# @name invokePostAction
+POST {{base}}/grants/{{createGrant.response.body.code}}/actions/calc-totals/invoke
 Content-Type: application/json
 
 {

--- a/src/grants/grant-repository.js
+++ b/src/grants/grant-repository.js
@@ -4,14 +4,20 @@ import { db } from "../common/db.js";
 
 const toDocument = (grant) => ({
   code: grant.code,
-  name: grant.name,
-  endpoints: grant.endpoints,
+  metadata: {
+    description: grant.metadata.description,
+    startDate: grant.metadata.startDate,
+  },
+  actions: grant.actions,
 });
 
 export const toGrant = (doc) => ({
   code: doc.code,
-  name: doc.name,
-  endpoints: doc.endpoints,
+  metadata: {
+    description: doc.metadata.description,
+    startDate: doc.metadata.startDate,
+  },
+  actions: doc.actions,
 });
 
 export const collection = "grants";

--- a/src/grants/grant-repository.test.js
+++ b/src/grants/grant-repository.test.js
@@ -18,8 +18,11 @@ describe("grantRepository", () => {
 
       await grantRepository.add({
         code: "1",
-        name: "test",
-        endpoints: [
+        metadata: {
+          description: "test",
+          startDate: "2021-01-01T00:00:00.000Z",
+        },
+        actions: [
           {
             method: "GET",
             name: "test",
@@ -31,8 +34,11 @@ describe("grantRepository", () => {
       assert.calledOnceWith(db.collection, "grants");
       assert.calledOnceWith(insertOne, {
         code: "1",
-        name: "test",
-        endpoints: [
+        metadata: {
+          description: "test",
+          startDate: "2021-01-01T00:00:00.000Z",
+        },
+        actions: [
           {
             method: "GET",
             name: "test",
@@ -60,8 +66,11 @@ describe("grantRepository", () => {
       await assert.rejects(
         grantRepository.add({
           code: "1",
-          name: "test",
-          endpoints: [
+          metadata: {
+            description: "test",
+            startDate: "2021-01-01T00:00:00.000Z",
+          },
+          actions: [
             {
               method: "GET",
               name: "test",
@@ -85,8 +94,11 @@ describe("grantRepository", () => {
       await assert.rejects(
         grantRepository.add({
           code: "1",
-          name: "test",
-          endpoints: [
+          metadata: {
+            description: "test",
+            startDate: "2021-01-01T00:00:00.000Z",
+          },
+          actions: [
             {
               method: "GET",
               name: "test",
@@ -104,8 +116,11 @@ describe("grantRepository", () => {
       const toArray = mock.fn(async () => [
         {
           code: "1",
-          name: "test 1",
-          endpoints: [
+          metadata: {
+            description: "test 1",
+            startDate: "2021-01-01T00:00:00.000Z",
+          },
+          actions: [
             {
               method: "GET",
               name: "test",
@@ -115,8 +130,11 @@ describe("grantRepository", () => {
         },
         {
           code: "2",
-          name: "test 2",
-          endpoints: [
+          metadata: {
+            description: "test 2",
+            startDate: "2021-01-02T00:00:00.000Z",
+          },
+          actions: [
             {
               method: "GET",
               name: "test",
@@ -139,8 +157,11 @@ describe("grantRepository", () => {
       assert.deepEqual(result, [
         {
           code: "1",
-          name: "test 1",
-          endpoints: [
+          metadata: {
+            description: "test 1",
+            startDate: "2021-01-01T00:00:00.000Z",
+          },
+          actions: [
             {
               method: "GET",
               name: "test",
@@ -150,8 +171,11 @@ describe("grantRepository", () => {
         },
         {
           code: "2",
-          name: "test 2",
-          endpoints: [
+          metadata: {
+            description: "test 2",
+            startDate: "2021-01-02T00:00:00.000Z",
+          },
+          actions: [
             {
               method: "GET",
               name: "test",
@@ -167,8 +191,11 @@ describe("grantRepository", () => {
     it("returns a Grant from the repository", async ({ mock }) => {
       const findOne = mock.fn(async () => ({
         code: "adding-value",
-        name: "test",
-        endpoints: [
+        metadata: {
+          description: "test",
+          startDate: "2021-01-01T00:00:00.000Z",
+        },
+        actions: [
           {
             method: "GET",
             name: "test",
@@ -189,8 +216,11 @@ describe("grantRepository", () => {
       });
       assert.deepEqual(result, {
         code: "adding-value",
-        name: "test",
-        endpoints: [
+        metadata: {
+          description: "test",
+          startDate: "2021-01-01T00:00:00.000Z",
+        },
+        actions: [
           {
             method: "GET",
             name: "test",

--- a/src/grants/grant-service.js
+++ b/src/grants/grant-service.js
@@ -28,9 +28,9 @@ export const grantService = {
     return grant;
   },
 
-  async invokeGetEndpoint({ code, name }) {
+  async invokeGetAction({ code, name }) {
     Grant.validateCode(code);
-    Grant.validateEndpointName(name);
+    Grant.validateActionName(name);
 
     const grant = await grantRepository.findByCode(code);
 
@@ -38,27 +38,27 @@ export const grantService = {
       throw Boom.notFound(`Grant with code "${code}" not found`);
     }
 
-    const endpoint = grant.endpoints.find(
+    const action = grant.actions.find(
       (e) => e.method === "GET" && e.name === name,
     );
 
-    if (!endpoint) {
+    if (!action) {
       throw Boom.badRequest(
-        `Grant with code "${code}" has no GET endpoint named "${name}"`,
+        `Grant with code "${code}" has no GET action named "${name}"`,
       );
     }
 
-    const response = await wreck.get(`${endpoint.url}?code=${code}`, {
+    const response = await wreck.get(`${action.url}?code=${code}`, {
       json: true,
     });
 
     return response.payload;
   },
 
-  async invokePostEndpoint({ code, name, payload }) {
+  async invokePostAction({ code, name, payload }) {
     Grant.validateCode(code);
-    Grant.validateEndpointName(name);
-    Grant.validateEndpointPayload(payload);
+    Grant.validateActionName(name);
+    Grant.validateActionPayload(payload);
 
     const grant = await grantRepository.findByCode(code);
 
@@ -66,17 +66,17 @@ export const grantService = {
       throw Boom.notFound(`Grant with code "${code}" not found`);
     }
 
-    const endpoint = grant.endpoints.find(
+    const action = grant.actions.find(
       (e) => e.method === "POST" && e.name === name,
     );
 
-    if (!endpoint) {
+    if (!action) {
       throw Boom.badRequest(
-        `Grant with code "${code}" has no POST endpoint named "${name}"`,
+        `Grant with code "${code}" has no POST action named "${name}"`,
       );
     }
 
-    const response = await wreck.post(endpoint.url, {
+    const response = await wreck.post(action.url, {
       payload,
       json: true,
     });

--- a/src/grants/grant.js
+++ b/src/grants/grant.js
@@ -1,53 +1,9 @@
 import Boom from "@hapi/boom";
-import Joi from "joi";
-
-const endpointNameSchema = Joi.object({
-  name: Joi.string()
-    .pattern(/^[a-z0-9-]+$/)
-    .min(1)
-    .max(30)
-    .required(),
-});
-
-const endpointMethodSchema = Joi.object({
-  method: Joi.string().valid("GET", "POST").required(),
-});
-
-const endpointUrlSchema = Joi.object({
-  url: Joi.string().uri().max(3000).required(),
-});
-
-const grantEndpointPayload = Joi.object({}).unknown(true).required();
-
-const endpointSchema = Joi.object({
-  endpoints: Joi.array()
-    .items(
-      Joi.object()
-        .concat(endpointNameSchema)
-        .concat(endpointMethodSchema)
-        .concat(endpointUrlSchema),
-    )
-    .max(20)
-    .required(),
-});
-
-const codeSchema = Joi.object({
-  code: Joi.string()
-    .pattern(/^[a-z0-9-]+$/)
-    .min(1)
-    .max(500)
-    .required(),
-});
-
-const createGrantSchema = Joi.object({
-  name: Joi.string().min(1).max(500).required(),
-})
-  .concat(codeSchema)
-  .concat(endpointSchema);
+import { schemas } from "./schemas.js";
 
 export const Grant = {
   create(props) {
-    const { error } = createGrantSchema.validate(props);
+    const { error } = schemas.createGrant.validate(props);
 
     if (error) {
       throw Boom.badRequest(error);
@@ -55,35 +11,37 @@ export const Grant = {
 
     return {
       code: props.code,
-      name: props.name,
-      endpoints: props.endpoints.map((e) => ({
+      metadata: {
+        description: props.metadata.description,
+        startDate: props.metadata.startDate,
+      },
+      actions: props.actions.map((e) => ({
         name: e.name,
         method: e.method,
         url: e.url,
       })),
+      questions: [],
     };
   },
 
   validateCode(code) {
-    const { error } = codeSchema.validate({ code });
-
-    if (error) {
-      throw Boom.badRequest(error);
-    }
-
-    return code;
-  },
-
-  validateEndpointName(name) {
-    const { error } = endpointNameSchema.validate({ name });
+    const { error } = schemas.code.validate(code);
 
     if (error) {
       throw Boom.badRequest(error);
     }
   },
 
-  validateEndpointPayload(payload) {
-    const { error } = grantEndpointPayload.validate(payload);
+  validateActionName(name) {
+    const { error } = schemas.actionName.validate(name);
+
+    if (error) {
+      throw Boom.badRequest(error);
+    }
+  },
+
+  validateActionPayload(payload) {
+    const { error } = schemas.actionPayload.validate(payload);
 
     if (error) {
       throw Boom.badRequest(error);

--- a/src/grants/grant.test.js
+++ b/src/grants/grant.test.js
@@ -5,23 +5,34 @@ import { Grant } from "./grant.js";
 describe("grant", () => {
   describe("create", () => {
     it("creates a grant with valid properties", () => {
+      const startDate = "2021-01-01T00:00:00.000Z";
+
       const grant = Grant.create({
-        name: "test grant",
         code: "test-code",
-        endpoints: [
+        metadata: {
+          description: "test description",
+          startDate,
+        },
+        actions: [
           {
-            name: "endpoint1",
+            name: "action1",
             method: "GET",
             url: "http://example.com",
           },
         ],
+        questions: [],
       });
 
       assert.equal(grant.code, "test-code");
-      assert.equal(grant.name, "test grant");
-      assert.deepEqual(grant.endpoints, [
+
+      assert.deepEqual(grant.metadata, {
+        description: "test description",
+        startDate,
+      });
+
+      assert.deepEqual(grant.actions, [
         {
-          name: "endpoint1",
+          name: "action1",
           method: "GET",
           url: "http://example.com",
         },
@@ -30,11 +41,13 @@ describe("grant", () => {
 
     it("throws when properties invalid", () => {
       const props = {
-        name: "",
-        code: "",
-        endpoints: [
+        code: "test-code",
+        metadata: {
+          description: "",
+        },
+        actions: [
           {
-            name: "endpoint1",
+            name: "action1",
             method: "INVALID",
             url: "invalid-url",
           },
@@ -42,7 +55,7 @@ describe("grant", () => {
       };
 
       assert.throws(() => Grant.create(props), {
-        message: '"name" is not allowed to be empty',
+        message: '"metadata.description" is not allowed to be empty',
       });
     });
   });
@@ -54,34 +67,32 @@ describe("grant", () => {
 
     it("throws an error for an invalid code", () => {
       assert.throws(() => Grant.validateCode(""), {
-        message: '"code" is not allowed to be empty',
+        message: '"value" is not allowed to be empty',
       });
     });
   });
 
-  describe("validateEndpointName", () => {
-    it("parses a valid endpoint name", () => {
+  describe("validateActionName", () => {
+    it("parses a valid action name", () => {
       assert.doesNotThrow(() => {
-        Grant.validateEndpointName("test-endpoint");
+        Grant.validateActionName("test-action");
       });
     });
 
-    it("throws an error for an invalid endpoint name", () => {
-      assert.throws(() => Grant.validateEndpointName(""), {
-        message: '"name" is not allowed to be empty',
+    it("throws an error for an invalid action name", () => {
+      assert.throws(() => Grant.validateActionName(""), {
+        message: '"value" is not allowed to be empty',
       });
     });
   });
 
-  describe("validateEndpointPayload", () => {
+  describe("validateActionPayload", () => {
     it("parses a valid payload", () => {
-      assert.doesNotThrow(() =>
-        Grant.validateEndpointPayload({ key: "value" }),
-      );
+      assert.doesNotThrow(() => Grant.validateActionPayload({ key: "value" }));
     });
 
     it("throws an error for an invalid payload", () => {
-      assert.throws(() => Grant.validateEndpointPayload(null), {
+      assert.throws(() => Grant.validateActionPayload(null), {
         message: '"value" must be of type object',
       });
     });

--- a/src/grants/index.js
+++ b/src/grants/index.js
@@ -28,8 +28,11 @@ export const grantsPlugin = {
 
         return grants.map((grant) => ({
           code: grant.code,
-          name: grant.name,
-          endpoints: grant.endpoints,
+          metadata: {
+            description: grant.metadata.description,
+            startDate: grant.metadata.startDate,
+          },
+          actions: grant.actions,
         }));
       },
     });
@@ -42,17 +45,20 @@ export const grantsPlugin = {
 
         return {
           code: grant.code,
-          name: grant.name,
-          endpoints: grant.endpoints,
+          metadata: {
+            description: grant.metadata.description,
+            startDate: grant.metadata.startDate,
+          },
+          actions: grant.actions,
         };
       },
     });
 
     server.route({
       method: "GET",
-      path: "/grants/{code}/endpoints/{name}/invoke",
+      path: "/grants/{code}/actions/{name}/invoke",
       async handler(request, _h) {
-        const result = await grantService.invokeGetEndpoint({
+        const result = await grantService.invokeGetAction({
           code: request.params.code,
           name: request.params.name,
         });
@@ -63,9 +69,9 @@ export const grantsPlugin = {
 
     server.route({
       method: "POST",
-      path: "/grants/{code}/endpoints/{name}/invoke",
+      path: "/grants/{code}/actions/{name}/invoke",
       async handler(request, _h) {
-        const result = await grantService.invokePostEndpoint({
+        const result = await grantService.invokePostAction({
           code: request.params.code,
           name: request.params.name,
           payload: request.payload,

--- a/src/grants/index.test.js
+++ b/src/grants/index.test.js
@@ -15,29 +15,34 @@ describe("grantsPlugin", () => {
 
   describe("POST /grants", () => {
     it("creates a new grant and returns the id", async ({ mock }) => {
-      mock.method(grantService, "create", async (props) => ({
-        code: "1",
-        ...props,
-      }));
+      mock.method(grantService, "create", async (props) => props);
 
       const { statusCode, result } = await server.inject({
         method: "POST",
         url: "/grants",
         payload: {
-          name: "test",
-          endpoints: [],
+          code: "test",
+          metadata: {
+            description: "test",
+            startDate: "2021-01-01T00:00:00.000Z",
+          },
+          actions: [],
         },
       });
 
       assert.calledOnceWith(grantService.create, {
-        name: "test",
-        endpoints: [],
+        code: "test",
+        metadata: {
+          description: "test",
+          startDate: "2021-01-01T00:00:00.000Z",
+        },
+        actions: [],
       });
 
       assert.equal(statusCode, 201);
 
       assert.deepEqual(result, {
-        code: "1",
+        code: "test",
       });
     });
   });
@@ -47,14 +52,20 @@ describe("grantsPlugin", () => {
       mock.method(grantService, "findAll", async () => [
         {
           code: "1",
-          name: "test 1",
-          endpoints: [],
+          metadata: {
+            description: "test 1",
+            startDate: "2021-01-01T00:00:00.000Z",
+          },
+          actions: [],
           internal: "this is private",
         },
         {
           code: "2",
-          name: "test 2",
-          endpoints: [],
+          metadata: {
+            description: "test 2",
+            startDate: "2021-01-01T00:00:00.000Z",
+          },
+          actions: [],
           internal: "this is private",
         },
       ]);
@@ -69,13 +80,19 @@ describe("grantsPlugin", () => {
       assert.deepEqual(result, [
         {
           code: "1",
-          name: "test 1",
-          endpoints: [],
+          metadata: {
+            description: "test 1",
+            startDate: "2021-01-01T00:00:00.000Z",
+          },
+          actions: [],
         },
         {
           code: "2",
-          name: "test 2",
-          endpoints: [],
+          metadata: {
+            description: "test 2",
+            startDate: "2021-01-01T00:00:00.000Z",
+          },
+          actions: [],
         },
       ]);
     });
@@ -85,8 +102,11 @@ describe("grantsPlugin", () => {
     it("returns matching grant", async ({ mock }) => {
       mock.method(grantService, "findByCode", async () => ({
         code: "adding-value",
-        name: "test 1",
-        endpoints: [],
+        metadata: {
+          description: "test 1",
+          startDate: "2021-01-01T00:00:00.000Z",
+        },
+        actions: [],
         internal: "this is private",
       }));
 
@@ -99,21 +119,24 @@ describe("grantsPlugin", () => {
 
       assert.deepEqual(result, {
         code: "adding-value",
-        name: "test 1",
-        endpoints: [],
+        metadata: {
+          description: "test 1",
+          startDate: "2021-01-01T00:00:00.000Z",
+        },
+        actions: [],
       });
     });
   });
 
-  describe("GET /grants/{code}/endpoints/{name}/invoke", () => {
-    it("returns response from endpoint", async ({ mock }) => {
-      mock.method(grantService, "invokeGetEndpoint", async () => ({
+  describe("GET /grants/{code}/actions/{name}/invoke", () => {
+    it("returns response from action", async ({ mock }) => {
+      mock.method(grantService, "invokeGetAction", async () => ({
         arbitrary: "result",
       }));
 
       const { statusCode, result } = await server.inject({
         method: "GET",
-        url: "/grants/adding-value/endpoints/test/invoke",
+        url: "/grants/adding-value/actions/test/invoke",
       });
 
       assert.equal(statusCode, 200);
@@ -122,22 +145,22 @@ describe("grantsPlugin", () => {
         arbitrary: "result",
       });
 
-      assert.calledOnceWith(grantService.invokeGetEndpoint, {
+      assert.calledOnceWith(grantService.invokeGetAction, {
         code: "adding-value",
         name: "test",
       });
     });
   });
 
-  describe("POST /grants/{code}/endpoints/{name}/invoke", () => {
-    it("returns response from endpoint", async ({ mock }) => {
-      mock.method(grantService, "invokePostEndpoint", async () => ({
+  describe("POST /grants/{code}/actions/{name}/invoke", () => {
+    it("returns response from action", async ({ mock }) => {
+      mock.method(grantService, "invokePostAction", async () => ({
         arbitrary: "result",
       }));
 
       const { statusCode, result } = await server.inject({
         method: "POST",
-        url: "/grants/adding-value/endpoints/test/invoke",
+        url: "/grants/adding-value/actions/test/invoke",
         payload: {
           code: "adding-value",
           name: "test",
@@ -150,7 +173,7 @@ describe("grantsPlugin", () => {
         arbitrary: "result",
       });
 
-      assert.calledOnceWith(grantService.invokePostEndpoint, {
+      assert.calledOnceWith(grantService.invokePostAction, {
         code: "adding-value",
         name: "test",
         payload: {

--- a/src/grants/schemas.js
+++ b/src/grants/schemas.js
@@ -1,0 +1,40 @@
+import Joi from "joi";
+
+const actionName = Joi.string()
+  .pattern(/^[a-z0-9-]+$/)
+  .min(1)
+  .max(30)
+  .required();
+
+const actionPayload = Joi.object({}).unknown(true).required();
+
+const action = Joi.object({
+  name: actionName,
+  method: Joi.string().valid("GET", "POST").required(),
+  url: Joi.string().uri().max(3000).required(),
+});
+
+const code = Joi.string()
+  .pattern(/^[a-z0-9-]+$/)
+  .min(1)
+  .max(500)
+  .required();
+
+const question = Joi.object({});
+
+const createGrant = Joi.object({
+  code,
+  metadata: Joi.object({
+    description: Joi.string().min(1).max(500).required(),
+    startDate: Joi.date().required(),
+  }),
+  questions: Joi.array().items(question).required(),
+  actions: Joi.array().items(action).max(20).required(),
+});
+
+export const schemas = {
+  code,
+  actionName,
+  actionPayload,
+  createGrant,
+};

--- a/test/fixtures/grants.js
+++ b/test/fixtures/grants.js
@@ -1,7 +1,10 @@
 export const grant1 = {
-  name: "test grant 1",
   code: "e2e-code1",
-  endpoints: [
+  metadata: {
+    description: "test grant 1",
+    startDate: "2021-01-01T00:00:00.000Z",
+  },
+  actions: [
     {
       name: "endpoint1",
       method: "GET",
@@ -11,9 +14,12 @@ export const grant1 = {
 };
 
 export const grant2 = {
-  name: "test grant 2",
   code: "e2e-code2",
-  endpoints: [
+  metadata: {
+    description: "test grant 2",
+    startDate: "2022-01-01T00:00:00.000Z",
+  },
+  actions: [
     {
       name: "endpoint1",
       method: "GET",

--- a/test/grant-api.test.js
+++ b/test/grant-api.test.js
@@ -59,9 +59,9 @@ describe("Grant API Tests", () => {
 
       const results = await db.collection(grantsCollection).find().toArray();
       assert.equal(results.length, 1);
-      assert.equal(results[0].name, grant1.name);
       assert.equal(results[0].code, grant1.code);
-      assert.deepEqual(results[0].endpoints, grant1.endpoints);
+      assert.equal(results[0].metadata.name, grant1.metadata.name);
+      assert.deepEqual(results[0].actions, grant1.actions);
     });
   });
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FUT-302

- Grant details pulled out into their own metadata slice as the field
count is going to grow.
- Grant "endpoints" renamed to "actions" as per
requirement and will require an accompanying PR which updates the URL
 for grant enablement https://github.com/DEFRA/forms-runner-v2/pull/77
