### PR TITLE
Add support for new approved application SNS topic in config

### DIFF
--- a/src/common/config.js
+++ b/src/common/config.js
@@ -21,6 +21,7 @@ const schema = Joi.object({
   MONGO_DATABASE: Joi.string(),
   TRACING_HEADER: Joi.string(),
   GRANT_APPLICATION_CREATED_TOPIC_ARN: Joi.string(),
+  GRANT_APPLICATION_APPROVED_TOPIC_ARN: Joi.string(),
   AWS_REGION: Joi.string(),
   AWS_ENDPOINT_URL: Joi.string().uri().optional(),
 }).options({
@@ -51,6 +52,7 @@ export const config = {
   mongoDatabase: vars.MONGO_DATABASE,
   tracingHeader: vars.TRACING_HEADER,
   grantApplicationCreatedTopic: vars.GRANT_APPLICATION_CREATED_TOPIC_ARN,
+  grantApplicationApprovedTopic: vars.GRANT_APPLICATION_APPROVED_TOPIC_ARN,
   region: vars.AWS_REGION,
   awsEndointUrl: vars.AWS_ENDPOINT_URL,
 };

--- a/src/common/config.js
+++ b/src/common/config.js
@@ -21,7 +21,7 @@ const schema = Joi.object({
   MONGO_DATABASE: Joi.string(),
   TRACING_HEADER: Joi.string(),
   GRANT_APPLICATION_CREATED_TOPIC_ARN: Joi.string(),
-  GRANT_APPLICATION_APPROVED_TOPIC_ARN: Joi.string(),
+  GRANT_APPLICATION_APPROVED_TOPIC_ARN: Joi.string().optional(),
   AWS_REGION: Joi.string(),
   AWS_ENDPOINT_URL: Joi.string().uri().optional(),
 }).options({


### PR DESCRIPTION
This update adds the GRANT_APPLICATION_APPROVED_TOPIC_ARN to the config validation and makes it available via the exported config object.
The ARN is already defined in cdp-app-config for all environments — this just wires it into the backend so it can be used when needed.