### PR TITLE
feature/FUT-467 - temporary update grant endpoint

### DIFF
--- a/src/grants/grant-repository.js
+++ b/src/grants/grant-repository.js
@@ -24,6 +24,20 @@ export const toGrant = (doc) => ({
 
 export const collection = "grants";
 
+export const replace = async (grant) => {
+  const grantDocument = toDocument(grant);
+  try {
+    await db.collection(collection).replaceOne(
+      {
+        code: grant.code,
+      },
+      grantDocument,
+    );
+  } catch (error) {
+    throw Boom.internal(error);
+  }
+};
+
 export const add = async (grant) => {
   const grantDocument = toDocument(grant);
 

--- a/src/grants/grant-repository.test.js
+++ b/src/grants/grant-repository.test.js
@@ -10,6 +10,81 @@ vi.mock("../common/db.js", () => ({
   },
 }));
 
+describe("replace", () => {
+  it("replaces a Grant in the repository", async () => {
+    const replaceOne = vi.fn().mockResolvedValueOnce({
+      insertedId: "code-1",
+    });
+
+    db.collection.mockReturnValue({
+      replaceOne,
+    });
+
+    await grantRepository.replace({
+      code: "code-1",
+      metadata: {
+        description: "test",
+        startDate: "2021-01-01T00:00:00.000Z",
+      },
+      actions: [
+        {
+          method: "GET",
+          name: "test-action",
+          url: "http://localhost",
+        },
+      ],
+      questions: [],
+    });
+
+    expect(db.collection).toHaveBeenCalledWith("grants");
+
+    expect(replaceOne).toHaveBeenCalledWith(
+      { code: "code-1" },
+      {
+        code: "code-1",
+        metadata: {
+          description: "test",
+          startDate: "2021-01-01T00:00:00.000Z",
+        },
+
+        actions: [
+          {
+            method: "GET",
+            name: "test-action",
+            url: "http://localhost",
+          },
+        ],
+        questions: [],
+      },
+    );
+  });
+  it("throws Boom.internal when an error occurs", async () => {
+    const error = new Error("test");
+
+    db.collection.mockReturnValue({
+      replaceOne: vi.fn().mockRejectedValueOnce(error),
+    });
+
+    const promise = grantRepository.replace({
+      code: "code-1",
+      metadata: {
+        description: "test",
+        startDate: "2021-01-01T00:00:00.000Z",
+      },
+      actions: [
+        {
+          method: "GET",
+          name: "test-action",
+          url: "http://localhost",
+        },
+      ],
+      questions: [],
+    });
+
+    await expect(promise).rejects.toThrow(Boom.internal(error));
+  });
+});
+
 describe("add", () => {
   it("stores a Grant in the repository", async () => {
     const insertOne = vi.fn().mockResolvedValueOnce({

--- a/src/grants/grant-service.js
+++ b/src/grants/grant-service.js
@@ -8,6 +8,14 @@ import { createApplication } from "./application.js";
 import { config } from "../common/config.js";
 import { publish } from "../common/sns.js";
 
+export const replace = async (props) => {
+  const grant = createGrant(props);
+
+  await grantRepository.replace(grant);
+
+  return grant;
+};
+
 export const create = async (props) => {
   const grant = createGrant(props);
 

--- a/src/grants/grant-service.test.js
+++ b/src/grants/grant-service.test.js
@@ -23,6 +23,7 @@ vi.mock("./grant.js", () => ({
 }));
 
 vi.mock("./grant-repository.js", () => ({
+  replace: vi.fn(),
   add: vi.fn(),
   findAll: vi.fn(),
   findByCode: vi.fn(),
@@ -31,6 +32,40 @@ vi.mock("./grant-repository.js", () => ({
 vi.mock("./application-repository.js", () => ({
   add: vi.fn(),
 }));
+
+describe("replace", () => {
+  it("replaces a grant", async () => {
+    const grant = {
+      code: "code-1",
+      name: "test",
+      actions: [
+        {
+          method: "GET",
+          name: "test",
+          url: "http://localhost",
+        },
+      ],
+    };
+
+    createGrant.mockReturnValueOnce(grant);
+
+    const result = await grantService.replace({
+      code: "code-1",
+      name: "test",
+      actions: [
+        {
+          method: "GET",
+          name: "test",
+          url: "http://localhost",
+        },
+      ],
+    });
+
+    expect(createGrant).toHaveBeenCalledWith(grant);
+    expect(grantRepository.replace).toHaveBeenCalledWith(grant);
+    expect(result).toEqual(grant);
+  });
+});
 
 describe("create", () => {
   it("stores the grant in the repository", async () => {

--- a/src/grants/index.js
+++ b/src/grants/index.js
@@ -52,7 +52,7 @@ export const grantsPlugin = {
           .response({
             code: grant.code,
           })
-          .code(201);
+          .code(200);
       },
     });
 

--- a/src/grants/index.js
+++ b/src/grants/index.js
@@ -44,7 +44,7 @@ export const grantsPlugin = {
         const exists = await grantService.findByCode(request.payload.code);
         if (!exists) {
           return Boom.notFound(
-            "Grant with id: " + request.params.code + " not found",
+            "Grant with code: " + request.params.code + " not found",
           );
         }
         const grant = await grantService.replace(request.payload);

--- a/src/grants/index.test.js
+++ b/src/grants/index.test.js
@@ -78,7 +78,7 @@ describe("PUT /tmp/grants", () => {
       payload: replaceRequest,
     });
 
-    expect(statusCode).toEqual(201);
+    expect(statusCode).toEqual(200);
 
     expect(grantService.replace).toHaveBeenCalledWith({
       code: "code-1",


### PR DESCRIPTION
To unblock other teams we’re opening up a temporary update/replace endpoint for grants.
[PUT] /temp/grants with the grant document as payload
- throws 404 if grant does not exist with grant.code
- returns 200 with grant.code if successful
- to test: 
  - fetch a grant using the swagger docs and update some of it's details
  - to see a successful request use the swagger docs [PUT] /temp/grants with the updated grant doc
  - change the grant.code to one that does not exist in the repository to see 404
  - update the grant document to include unsupported data to see 400 bad request

https://eaflood.atlassian.net/jira/software/projects/FUT/boards/1668?selectedIssue=FUT-467