### PR TITLE
Feature/FUT-462 - Adds traceId across message events

### DIFF
--- a/src/common/sns.js
+++ b/src/common/sns.js
@@ -1,5 +1,6 @@
 import { SNSClient, PublishCommand } from "@aws-sdk/client-sns";
 import { config } from "./config.js";
+import { getTraceId } from "@defra/hapi-tracing";
 
 export const snsClient = new SNSClient({
   region: config.region,
@@ -12,10 +13,10 @@ export const snsClient = new SNSClient({
  * @param {JSON} message
  * @returns
  */
-export const publish = async (topicArn, message) => {
+export const publish = async (topicArn, message, traceId) => {
   return snsClient.send(
     new PublishCommand({
-      Message: JSON.stringify(message),
+      Message: JSON.stringify({ ...message, traceId: traceId || getTraceId() }),
       TopicArn: topicArn,
     }),
   );

--- a/src/events/case-stage-updates-queue-event-handler.js
+++ b/src/events/case-stage-updates-queue-event-handler.js
@@ -11,6 +11,8 @@ const caseStageUpdatesQueueEventHandler = (server) => async (message) => {
 
   const messageBody = JSON.parse(message.Body);
 
+  const traceId = messageBody.data.traceId;
+
   const application = await grantService.findApplicationByClientRef(
     messageBody.data.caseRef,
   );
@@ -25,7 +27,7 @@ const caseStageUpdatesQueueEventHandler = (server) => async (message) => {
       data: application,
     };
 
-    await sns.publish(config.grantApplicationApprovedTopic, event);
+    await sns.publish(config.grantApplicationApprovedTopic, event, traceId);
 
     server.logger.info({
       message: `Grant approval event sent: ${event.id}`,

--- a/src/grants/grant-service.js
+++ b/src/grants/grant-service.js
@@ -7,6 +7,7 @@ import { createApplication } from "./application.js";
 
 import { config } from "../common/config.js";
 import { publish } from "../common/sns.js";
+import { getTraceId } from "@defra/hapi-tracing";
 
 export const create = async (props) => {
   const grant = createGrant(props);
@@ -103,5 +104,5 @@ export const submitApplication = async (code, createApplicationRequest) => {
 
   await applicationRepository.add(application);
 
-  await publish(config.grantApplicationCreatedTopic, application);
+  await publish(config.grantApplicationCreatedTopic, application, getTraceId());
 };


### PR DESCRIPTION
- pass along the traceId from CW events
- or default to the request's Id when creating application

… meaning requests from external services that pass the traceId can be tracked across cw apps

https://eaflood.atlassian.net/jira/software/projects/FUT/boards/1668?selectedIssue=FUT-462