### PR TITLE
feat/FPG-574: update case application status commands

### DIFF
--- a/src/grants/commands/update-case-status.command.js
+++ b/src/grants/commands/update-case-status.command.js
@@ -1,15 +1,23 @@
 import { CloudEvent } from "../../common/cloud-event.js";
 
 export class UpdateCaseStatusCommand extends CloudEvent {
-  constructor({ newStatus, caseRef, workflowCode, data }) {
+  constructor({
+    newStatus,
+    caseRef,
+    workflowCode,
+    phase,
+    stage,
+    targetNode,
+    data,
+  }) {
     super("case.update.status", {
       caseRef,
       workflowCode,
       newStatus,
       supplementaryData: {
-        phase: "PRE_AWARD",
-        stage: "AWARD",
-        targetNode: "agreements",
+        targetNode,
+        phase,
+        stage,
         data,
       },
     });

--- a/src/grants/publishers/case-event.publisher.js
+++ b/src/grants/publishers/case-event.publisher.js
@@ -8,7 +8,7 @@ export const publishCreateNewCase = async (application) => {
   await publish(config.sns.createNewCaseTopicArn, event);
 };
 
-export const publishUpdateCaseStatus = async ({
+export const publishUpdateCaseStatusWithAgreementData = async ({
   newStatus,
   caseRef,
   workflowCode,
@@ -18,6 +18,9 @@ export const publishUpdateCaseStatus = async ({
     newStatus,
     caseRef,
     workflowCode,
+    phase: null,
+    stage: null,
+    targetNode: "agreements",
     data,
   });
   await publish(config.sns.updateCaseStatusTopicArn, event);

--- a/src/grants/publishers/case-event.publisher.test.js
+++ b/src/grants/publishers/case-event.publisher.test.js
@@ -10,7 +10,7 @@ import {
 } from "../models/application.js";
 import {
   publishCreateNewCase,
-  publishUpdateCaseStatus,
+  publishUpdateCaseStatusWithAgreementData,
 } from "./case-event.publisher.js";
 
 vi.mock("../../common/sns-client.js");
@@ -71,7 +71,7 @@ describe("publishCreateNewCase", () => {
 
 describe("publishUpdateApplicationStatus", () => {
   it("should publish status update command", async () => {
-    await publishUpdateCaseStatus({
+    await publishUpdateCaseStatusWithAgreementData({
       clientRef: "1w4",
       code: "grant-code",
       agreementData: {

--- a/src/grants/use-cases/accept-agreement.use-case.js
+++ b/src/grants/use-cases/accept-agreement.use-case.js
@@ -1,6 +1,6 @@
 import { CaseStatus } from "../models/case-status.js";
 import { publishApplicationStatusUpdated } from "../publishers/application-event.publisher.js";
-import { publishUpdateCaseStatus } from "../publishers/case-event.publisher.js";
+import { publishUpdateCaseStatusWithAgreementData } from "../publishers/case-event.publisher.js";
 import { update } from "../repositories/application.repository.js";
 import { findApplicationByClientRefAndCodeUseCase } from "./find-application-by-client-ref-and-code.use-case.js";
 
@@ -30,7 +30,7 @@ export const acceptAgreementUseCase = async ({
 
   const agreement = application.getAgreement(agreementRef);
 
-  await publishUpdateCaseStatus({
+  await publishUpdateCaseStatusWithAgreementData({
     caseRef: clientRef,
     workflowCode: code,
     newStatus: CaseStatus.OfferAccepted,

--- a/src/grants/use-cases/accept-agreement.use-case.test.js
+++ b/src/grants/use-cases/accept-agreement.use-case.test.js
@@ -12,7 +12,7 @@ import {
 } from "../models/application.js";
 import { CaseStatus } from "../models/case-status.js";
 import { publishApplicationStatusUpdated } from "../publishers/application-event.publisher.js";
-import { publishUpdateCaseStatus } from "../publishers/case-event.publisher.js";
+import { publishUpdateCaseStatusWithAgreementData } from "../publishers/case-event.publisher.js";
 import { update } from "../repositories/application.repository.js";
 import { acceptAgreementUseCase } from "./accept-agreement.use-case.js";
 import { findApplicationByClientRefAndCodeUseCase } from "./find-application-by-client-ref-and-code.use-case.js";
@@ -113,7 +113,7 @@ describe("acceptAgreementUseCase", () => {
   });
 
   it("publishes the case status update", () => {
-    expect(publishUpdateCaseStatus).toHaveBeenCalledWith({
+    expect(publishUpdateCaseStatusWithAgreementData).toHaveBeenCalledWith({
       caseRef: "test-client-ref",
       workflowCode: "test-code",
       newStatus: CaseStatus.OfferAccepted,

--- a/src/grants/use-cases/add-agreement.use-case.js
+++ b/src/grants/use-cases/add-agreement.use-case.js
@@ -1,7 +1,7 @@
 import { Agreement } from "../models/agreement.js";
 import { CaseStatus } from "../models/case-status.js";
 import { publishApplicationStatusUpdated } from "../publishers/application-event.publisher.js";
-import { publishUpdateCaseStatus } from "../publishers/case-event.publisher.js";
+import { publishUpdateCaseStatusWithAgreementData } from "../publishers/case-event.publisher.js";
 import { update } from "../repositories/application.repository.js";
 import { findApplicationByClientRefAndCodeUseCase } from "./find-application-by-client-ref-and-code.use-case.js";
 
@@ -33,7 +33,7 @@ export const addAgreementUseCase = async ({
     newStatus: application.getFullyQualifiedStatus(),
   });
 
-  await publishUpdateCaseStatus({
+  await publishUpdateCaseStatusWithAgreementData({
     caseRef: clientRef,
     workflowCode: code,
     newStatus: CaseStatus.Review,

--- a/src/grants/use-cases/add-agreement.use-case.test.js
+++ b/src/grants/use-cases/add-agreement.use-case.test.js
@@ -12,7 +12,7 @@ import {
 } from "../models/application.js";
 import { CaseStatus } from "../models/case-status.js";
 import { publishApplicationStatusUpdated } from "../publishers/application-event.publisher.js";
-import { publishUpdateCaseStatus } from "../publishers/case-event.publisher.js";
+import { publishUpdateCaseStatusWithAgreementData } from "../publishers/case-event.publisher.js";
 import { update } from "../repositories/application.repository.js";
 import { addAgreementUseCase } from "./add-agreement.use-case.js";
 import { findApplicationByClientRefAndCodeUseCase } from "./find-application-by-client-ref-and-code.use-case.js";
@@ -91,7 +91,7 @@ describe("addAgreementUseCase", () => {
   });
 
   it("publishes the case status update", () => {
-    expect(publishUpdateCaseStatus).toHaveBeenCalledWith({
+    expect(publishUpdateCaseStatusWithAgreementData).toHaveBeenCalledWith({
       caseRef: "test-client-ref",
       workflowCode: "test-code",
       newStatus: CaseStatus.Review,

--- a/src/grants/use-cases/withdraw-agreement.use-case.js
+++ b/src/grants/use-cases/withdraw-agreement.use-case.js
@@ -1,6 +1,6 @@
 import { CaseStatus } from "../models/case-status.js";
 import { publishApplicationStatusUpdated } from "../publishers/application-event.publisher.js";
-import { publishUpdateCaseStatus } from "../publishers/case-event.publisher.js";
+import { publishUpdateCaseStatusWithAgreementData } from "../publishers/case-event.publisher.js";
 import { update } from "../repositories/application.repository.js";
 import { findApplicationByClientRefAndCodeUseCase } from "./find-application-by-client-ref-and-code.use-case.js";
 
@@ -30,7 +30,7 @@ export const withdrawAgreementUseCase = async ({
     currentStatus: application.getFullyQualifiedStatus(),
   });
 
-  await publishUpdateCaseStatus({
+  await publishUpdateCaseStatusWithAgreementData({
     caseRef: clientRef,
     workflowCode: code,
     newStatus: CaseStatus.OfferWithdrawn,

--- a/src/grants/use-cases/withdraw-agreement.use-case.test.js
+++ b/src/grants/use-cases/withdraw-agreement.use-case.test.js
@@ -12,7 +12,7 @@ import {
 } from "../models/application.js";
 import { CaseStatus } from "../models/case-status.js";
 import { publishApplicationStatusUpdated } from "../publishers/application-event.publisher.js";
-import { publishUpdateCaseStatus } from "../publishers/case-event.publisher.js";
+import { publishUpdateCaseStatusWithAgreementData } from "../publishers/case-event.publisher.js";
 import { update } from "../repositories/application.repository.js";
 import { findApplicationByClientRefAndCodeUseCase } from "./find-application-by-client-ref-and-code.use-case.js";
 import { withdrawAgreementUseCase } from "./withdraw-agreement.use-case.js";
@@ -113,7 +113,7 @@ describe("withdrawAgreementUseCase", () => {
   });
 
   it("publishes the case status update", () => {
-    expect(publishUpdateCaseStatus).toHaveBeenCalledWith({
+    expect(publishUpdateCaseStatusWithAgreementData).toHaveBeenCalledWith({
       caseRef: "test-client-ref",
       workflowCode: "test-code",
       newStatus: CaseStatus.OfferWithdrawn,


### PR DESCRIPTION
- As part of FPG-574 we're now removing phase and stage (passing null) on the update case status command when an agreement status changes.
- Rename the command to be specific to the agreement status update so that future case status updates can be accommodated 