### PR TITLE
FGP-1118: acknowledge unknown transitions without throwing and error

### DIFF
--- a/src/grants/models/grant.js
+++ b/src/grants/models/grant.js
@@ -96,6 +96,20 @@ export class Grant {
     );
   }
 
+  hasExternalStatusMapping(
+    externalRequestedState,
+    source,
+    currentPhase,
+    currentStage,
+  ) {
+    return this.#findExternalStatusMapping(
+      currentPhase,
+      currentStage,
+      externalRequestedState,
+      source,
+    );
+  }
+
   // eslint-disable-next-line complexity
   #findExternalStatusMapping(
     currentPhase,

--- a/src/grants/services/apply-event-status-change.service.js
+++ b/src/grants/services/apply-event-status-change.service.js
@@ -160,6 +160,21 @@ const saveApplication = async (updatedApplication, session) => {
   return { application: updatedApplication };
 };
 
+const checkForExternalStatusMapping = (
+  grant,
+  requestedStatus,
+  sourceSystem,
+  currentPhase,
+  currentStage,
+) => {
+  return grant.hasExternalStatusMapping(
+    requestedStatus,
+    sourceSystem,
+    currentPhase,
+    currentStage,
+  );
+};
+
 /**
  * Main entry point for applying external status changes to grant applications.
  *
@@ -191,6 +206,21 @@ export const applyExternalStateChange = async (command) => {
 
     if (!grant) {
       throw Boom.notFound(`Grant with code "${application.code}" not found`);
+    }
+
+    if (
+      !checkForExternalStatusMapping(
+        grant,
+        command.externalRequestedState,
+        command.sourceSystem,
+        application.currentPhase,
+        application.currentStage,
+      )
+    ) {
+      logger.info(
+        `Acknowledged unknown transition for grantCode ${code} from current position ${application.getFullyQualifiedStatus()} to target position ${command.externalRequestedState} for clientRef ${application.clientRef}`,
+      );
+      return;
     }
 
     const result = processStateTransition(application, grant, command);

--- a/src/grants/services/apply-event-status-change.service.test.js
+++ b/src/grants/services/apply-event-status-change.service.test.js
@@ -317,20 +317,20 @@ describe("applyExternalStateChange", () => {
 
   describe("when external status is not mapped", () => {
     it("should not update application", async () => {
+      const spy = vi.spyOn(logger, "info");
       findByClientRefAndCode.mockResolvedValue(mockApplication);
       findByCode.mockResolvedValue(mockGrant);
 
-      await expect(() =>
-        applyExternalStateChange({
-          clientRef: "APP-123",
-          externalRequestedState: "UNMAPPED_STATUS",
-          sourceSystem: "CW",
-          eventData: {},
-        }),
-      ).rejects.toThrow(
-        "Unable to process state change from PRE_AWARD:REVIEW_APPLICATION:RECEIVED to UNMAPPED_STATUS",
-      );
+      await applyExternalStateChange({
+        clientRef: "APP-123",
+        externalRequestedState: "UNMAPPED_STATUS",
+        sourceSystem: "CW",
+        eventData: {},
+      });
 
+      expect(spy.mock.lastCall[0]).toBe(
+        "Acknowledged unknown transition for grantCode undefined from current position PRE_AWARD:REVIEW_APPLICATION:RECEIVED to target position UNMAPPED_STATUS for clientRef APP-123",
+      );
       expect(update).not.toHaveBeenCalled();
       expect(insertMany).not.toHaveBeenCalled();
     });
@@ -365,21 +365,21 @@ describe("applyExternalStateChange", () => {
 
   describe("when source system is different", () => {
     it("should not find mapping and not update application", async () => {
+      const spy = vi.spyOn(logger, "info");
       findByClientRefAndCode.mockResolvedValue(mockApplication);
       findByCode.mockResolvedValue(mockGrant);
 
-      await expect(() =>
-        applyExternalStateChange({
-          clientRef: "APP-123",
-          code: "foo",
-          externalRequestedState: "IN_PROGRESS",
-          sourceSystem: "DIFFERENT_SYSTEM",
-          eventData: {},
-        }),
-      ).rejects.toThrow(
-        "Unable to process state change from PRE_AWARD:REVIEW_APPLICATION:RECEIVED to IN_PROGRESS",
-      );
+      await applyExternalStateChange({
+        clientRef: "APP-123",
+        code: "foo",
+        externalRequestedState: "IN_PROGRESS",
+        sourceSystem: "DIFFERENT_SYSTEM",
+        eventData: {},
+      });
 
+      expect(spy.mock.lastCall[0]).toBe(
+        "Acknowledged unknown transition for grantCode foo from current position PRE_AWARD:REVIEW_APPLICATION:RECEIVED to target position IN_PROGRESS for clientRef APP-123",
+      );
       expect(update).not.toHaveBeenCalled();
       expect(insertMany).not.toHaveBeenCalled();
     });
@@ -888,6 +888,8 @@ describe("applyExternalStateChange", () => {
         currentStatus: "RECEIVED",
       });
 
+      const spy = vi.spyOn(logger, "info");
+
       const grantWithNoMapping = new Grant({
         ...mockGrant,
         externalStatusMap: undefined,
@@ -896,24 +898,24 @@ describe("applyExternalStateChange", () => {
       findByClientRefAndCode.mockResolvedValue(application);
       findByCode.mockResolvedValue(grantWithNoMapping);
 
-      await expect(() =>
-        applyExternalStateChange({
-          clientRef: "APP-123",
-          code: "foo",
-          externalRequestedState: "IN_PROGRESS",
-          sourceSystem: "CW",
-          eventData: {},
-        }),
-      ).rejects.toThrow(
-        "Unable to process state change from PRE_AWARD:REVIEW_APPLICATION:RECEIVED to IN_PROGRESS",
-      );
+      await applyExternalStateChange({
+        clientRef: "APP-123",
+        code: "foo",
+        externalRequestedState: "IN_PROGRESS",
+        sourceSystem: "CW",
+        eventData: {},
+      });
 
+      expect(spy.mock.lastCall[0]).toBe(
+        "Acknowledged unknown transition for grantCode foo from current position PRE_AWARD:REVIEW_APPLICATION:RECEIVED to target position IN_PROGRESS for clientRef APP-123",
+      );
       expect(update).not.toHaveBeenCalled();
     });
   });
 
   describe("when externalStatusMap phases is missing", () => {
     it("should not update application", async () => {
+      const spy = vi.spyOn(logger, "info");
       const application = new Application({
         ...mockApplication,
         currentStatus: "RECEIVED",
@@ -927,18 +929,17 @@ describe("applyExternalStateChange", () => {
       findByClientRefAndCode.mockResolvedValue(application);
       findByCode.mockResolvedValue(grantWithNoPhases);
 
-      await expect(() =>
-        applyExternalStateChange({
-          clientRef: "APP-123",
-          code: "foo",
-          externalRequestedState: "IN_PROGRESS",
-          sourceSystem: "CW",
-          eventData: {},
-        }),
-      ).rejects.toThrow(
-        "Unable to process state change from PRE_AWARD:REVIEW_APPLICATION:RECEIVED to IN_PROGRESS",
-      );
+      await applyExternalStateChange({
+        clientRef: "APP-123",
+        code: "foo",
+        externalRequestedState: "IN_PROGRESS",
+        sourceSystem: "CW",
+        eventData: {},
+      });
 
+      expect(spy.mock.lastCall[0]).toBe(
+        "Acknowledged unknown transition for grantCode foo from current position PRE_AWARD:REVIEW_APPLICATION:RECEIVED to target position IN_PROGRESS for clientRef APP-123",
+      );
       expect(update).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/c/projects/FGP/boards/7369?selectedIssue=FGP-1118

Gas can now handle unknown external transitions without throwing an error - reducing the one-to-one mapping of statuses in CE and Gas