### PR TITLE
FGP-1149: adds migration to roll back outbox status for broken wmp application

### DIFF
--- a/migrations/20260605134008-fix-wmp-outbox-status.js
+++ b/migrations/20260605134008-fix-wmp-outbox-status.js
@@ -1,15 +1,20 @@
 export const up = async (db) => {
   await db.collection("outbox").updateMany(
     {
-      "event.type": "cloud.defra.local.fg-gas-backend.agreement.create",
+      "event.type": /agreement\.create$/,
       "event.data.clientRef": {
-        $in: ["wmp-398-75z", "WMP-REF-UK5", "wmp-ref-uk5"],
+        $in: ["wmp-398-75z", "WMP-398-75Z", "WMP-REF-UK5", "wmp-ref-uk5"],
       },
+      "event.data.code": "woodland",
     },
     {
       $set: {
-        status: "PUBLISHED",
+        status: "RESUBMITTED",
+        claimedBy: null,
+        claimedAt: null,
+        claimExpiresAt: null,
         completionDate: null,
+        lastResubmissionDate: new Date().toISOString(),
       },
     },
   );

--- a/migrations/20260605134008-fix-wmp-outbox-status.js
+++ b/migrations/20260605134008-fix-wmp-outbox-status.js
@@ -1,0 +1,16 @@
+export const up = async (db) => {
+  await db.collection("outbox").updateMany(
+    {
+      "event.type": "cloud.defra.local.fg-gas-backend.agreement.create",
+      "event.data.clientRef": {
+        $in: ["wmp-398-75z", "WMP-REF-UK5", "wmp-ref-uk5"],
+      },
+    },
+    {
+      $set: {
+        status: "PUBLISHED",
+        completionDate: null,
+      },
+    },
+  );
+};

--- a/migrations/20260605134008-fix-wmp-outbox-status.js
+++ b/migrations/20260605134008-fix-wmp-outbox-status.js
@@ -14,6 +14,7 @@ export const up = async (db) => {
         claimedAt: null,
         claimExpiresAt: null,
         completionDate: null,
+        completionAttempts: 0,
         lastResubmissionDate: new Date().toISOString(),
       },
     },


### PR DESCRIPTION
- roll back the status for two outbox events to allow them to be replayed
https://eaflood.atlassian.net/browse/FGP-1149