### PR TITLE
trying proxies for audit events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@aws-sdk/client-sns": "^3.995.0",
         "@aws-sdk/client-sqs": "^3.995.0",
         "@aws-sdk/credential-providers": "^3.1004.0",
+        "@defra/fcp-audit-publisher": "^1.0.5",
         "@defra/hapi-tracing": "^1.28.0",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@hapi/boom": "^10.0.1",
@@ -960,6 +961,36 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@defra/fcp-audit-publisher": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@defra/fcp-audit-publisher/-/fcp-audit-publisher-1.0.6.tgz",
+      "integrity": "sha512-y2uyWM02OTpANPfIuUDrKLJYlIvqnZAIQU7WxDA8fL5L+dM3Q+mBV45Ujka8W2aLAieEm4Jf4nvMeZS25EtHrQ==",
+      "license": "OGL-UK-3.0",
+      "dependencies": {
+        "joi": "18.1.2"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sns": ">=3"
+      }
+    },
+    "node_modules/@defra/fcp-audit-publisher/node_modules/joi": {
+      "version": "18.1.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.1.2.tgz",
+      "integrity": "sha512-rF5MAmps5esSlhCA+N1b6IYHDw9j/btzGaqfgie522jS02Ju/HXBxamlXVlKEHAxoMKQL77HWI8jlqWsFuekZA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@defra/hapi-tracing": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/@defra/hapi-tracing/-/hapi-tracing-1.30.0.tgz",
@@ -1255,6 +1286,18 @@
         "@hapi/hoek": "^11.0.2"
       }
     },
+    "node_modules/@hapi/address": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
+      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@hapi/ammo": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-6.0.1.tgz",
@@ -1355,6 +1398,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/file/-/file-3.0.0.tgz",
       "integrity": "sha512-w+lKW+yRrLhJu620jT3y+5g2mHqnKfepreykvdOcl9/6up8GrQQn+l3FRTsjHTKbkbfQFkuksHpdv2EcpKcJ4Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/formula": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
+      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@hapi/hapi": {
@@ -1466,6 +1515,12 @@
         "@hapi/nigel": "^5.0.1"
       }
     },
+    "node_modules/@hapi/pinpoint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
+      "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@hapi/podium": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-5.0.2.tgz",
@@ -1531,6 +1586,15 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-6.0.1.tgz",
       "integrity": "sha512-52OXRslUfYwXAOG8k58f2h2ngXYQGP0x5RPOo+eWA/FtyLgHjGMrE3+e9LSXP/0q2YfHAK5wj9aA9DTy1K+kyQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/tlds": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.7.tgz",
+      "integrity": "sha512-MgNjRwy9Ti92yVAixLmDc8dd1bJIKwO9qlWCfFQRwRmUEDPQHYn4G6hwPFvFGUTzAa0FsS+inMjLin7GnyBRhA==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=14.0.0"
@@ -2984,7 +3048,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@stylistic/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@aws-sdk/client-sns": "^3.995.0",
     "@aws-sdk/client-sqs": "^3.995.0",
     "@aws-sdk/credential-providers": "^3.1004.0",
+    "@defra/fcp-audit-publisher": "^1.0.5",
     "@defra/hapi-tracing": "^1.28.0",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@hapi/boom": "^10.0.1",

--- a/src/common/audit-constants.js
+++ b/src/common/audit-constants.js
@@ -1,0 +1,29 @@
+export const buildAuditEvent = ({
+  entity,
+  action,
+  entityid,
+  details = {},
+  messageGroupId,
+  security,
+}) => ({
+  entities: [{ entity, action, entityid }],
+  details,
+  messageGroupId: messageGroupId ?? entityid,
+  ...(security && { security }),
+});
+
+export const auditEntities = {
+  APPLICATION: "Application",
+  AGREEMENT: "Agreement",
+  GRANT: "Grant",
+};
+
+export const auditActions = {
+  CREATE_APPLICATION: "CREATE_APPLICATION",
+  SUBMIT_APPLICATION: "SUBMIT_APPLICATION",
+  REPLACE_APPLICATION: "REPLACE_APPLICATION",
+  APPROVE_APPLICATION: "APPROVE_APPLICATION",
+  STATUS_TRANSITION: "STATUS_TRANSITION",
+  CANCEL_AGREEMENT: "CANCEL_AGREEMENT",
+  REPLACE_GRANT: "REPLACE_GRANT",
+};

--- a/src/common/config.js
+++ b/src/common/config.js
@@ -40,6 +40,7 @@ const schema = Joi.object({
   GAS__SQS__UPDATE_STATUS_QUEUE_URL: Joi.string().uri().optional(),
   GAS__SQS__UPDATE_AGREEMENT_STATUS_QUEUE_URL: Joi.string().uri().optional(),
   GAS__SNS__UPDATE_AGREEMENT_STATUS_TOPIC_ARN: Joi.string().optional(),
+  GAS__SNS__AUDIT_TOPIC_ARN: Joi.string(),
 }).options({
   stripUnknown: true,
   allowUnknown: true,
@@ -96,6 +97,7 @@ export const config = {
       vars.GAS__SNS__GRANT_APPLICATION_STATUS_UPDATED_TOPIC_ARN,
     createNewCaseTopicArn: vars.GAS__SNS__CREATE_NEW_CASE_TOPIC_ARN,
     updateCaseStatusTopicArn: vars.GAS__SNS__UPDATE_CASE_STATUS_TOPIC_ARN,
+    auditTopicArn: vars.GAS__SNS__AUDIT_TOPIC_ARN,
   },
   sqs: {
     updateStatusQueueUrl: vars.GAS__SQS__UPDATE_STATUS_QUEUE_URL,

--- a/src/common/request-context.js
+++ b/src/common/request-context.js
@@ -1,0 +1,8 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const asyncLocalStorage = new AsyncLocalStorage();
+
+export const withRequestContext = (context, fn) =>
+  asyncLocalStorage.run(context, fn);
+
+export const getRequestContext = () => asyncLocalStorage.getStore() ?? null;

--- a/src/common/sns-client.js
+++ b/src/common/sns-client.js
@@ -2,18 +2,21 @@ import { PublishCommand, SNSClient } from "@aws-sdk/client-sns";
 import { config } from "./config.js";
 import { logger } from "./logger.js";
 
-const snsClient = new SNSClient({
+export const snsClient = new SNSClient({
   region: config.region,
   endpoint: config.awsEndpointUrl,
 });
 
 export const publish = async (topic, data, messageGroupId) => {
-  logger.info(`Publish command ${topic}`);
+  logger.info(`Publish command ${topic} ${messageGroupId}`);
+  const messageGroup = topic.endsWith(".fifo") && {
+    MessageGroupId: messageGroupId,
+  };
   await snsClient.send(
     new PublishCommand({
       TopicArn: topic,
       Message: JSON.stringify(data),
-      MessageGroupId: messageGroupId,
+      ...messageGroup,
     }),
   );
 };

--- a/src/common/with-audit.js
+++ b/src/common/with-audit.js
@@ -1,0 +1,38 @@
+import { logger } from "./logger.js";
+import { writeAuditEvent } from "./write-audit-event.js";
+
+export const withAudit = (f, dataBuilder) =>
+  new Proxy(f, {
+    async apply(target, _, args) {
+      console.log("--------- with audit proxy --------- ");
+      console.log("args", args);
+
+      let result;
+      let status = "SUCCESS";
+      let session = args[1];
+      try {
+        result = await target.apply(_, args);
+      } catch (e) {
+        status = "FAILURE";
+        session = null;
+        throw e;
+      } finally {
+        console.log(
+          "----------- Use case result within proxy ----------- ",
+          result,
+        );
+        const { entities, details, messageGroupId, security } = dataBuilder(
+          args,
+          result,
+        );
+        console.log({ entities });
+        writeAuditEvent(
+          { entities, details, messageGroupId, security, status },
+          session,
+        ).catch((auditError) => {
+          logger.error(auditError, "Failed to write audit event");
+        });
+      }
+      return result;
+    },
+  });

--- a/src/common/write-audit-event.js
+++ b/src/common/write-audit-event.js
@@ -1,0 +1,81 @@
+import { validateAuditEvent } from "@defra/fcp-audit-publisher";
+import { getTraceId } from "@defra/hapi-tracing";
+import { randomUUID } from "node:crypto";
+import { networkInterfaces } from "node:os";
+import { Outbox } from "../grants/models/outbox.js";
+import { insertMany } from "../grants/repositories/outbox.repository.js";
+import { config } from "./config.js";
+import { logger } from "./logger.js";
+import { getRequestContext } from "./request-context.js";
+
+export const SUCCESS = "SUCCESS";
+export const FAILURE = "FAILURE";
+
+const getServiceIp = () => {
+  for (const iface of Object.values(networkInterfaces())) {
+    const addr = iface.find((n) => n.family === "IPv4" && !n.internal);
+    if (addr) return addr.address;
+  }
+  return null;
+};
+
+const createAuditPayload = (entities, details, status, context) => ({
+  entities,
+  status,
+  details: {
+    ...(context?.subject && { subject: context.subject }),
+    ...details,
+  },
+});
+
+const buildSecurity = (security) => security && { security };
+const getCorrelationId = () => getTraceId() ?? randomUUID();
+const getUser = (context) => context?.user ?? undefined;
+const getSession = (context) => context?.sessionId ?? undefined;
+const getIP = (context) => context?.ip ?? getServiceIp();
+
+const buildPayload = (context, { entities, details, status, security }) => ({
+  datetime: new Date().toISOString(),
+  version: config.serviceVersion,
+  application: config.serviceName,
+  component: config.serviceName,
+  environment: config.cdpEnvironment,
+  correlationid: getCorrelationId(),
+  user: getUser(context),
+  sessionid: getSession(context),
+  ip: getIP(context),
+  audit: createAuditPayload(entities, details, status, context),
+  security: buildSecurity(security),
+});
+
+export const writeAuditEvent = async (
+  { entities, details, messageGroupId, status, security },
+  session,
+) => {
+  logger.info("Begin write audit event.");
+  const context = getRequestContext();
+  const payload = buildPayload(context, {
+    entities,
+    details,
+    status,
+    security,
+  });
+
+  logger.info(context, "audit context");
+  logger.info(payload, "audit payload");
+  const { valid, errors } = validateAuditEvent(payload);
+  if (!valid) {
+    logger.warn({ errors }, "Audit event failed validation - not writing");
+    return;
+  }
+
+  const msgGroupId = messageGroupId ?? randomUUID();
+  const outboxEntry = new Outbox({
+    event: { ...payload, messageGroupId: msgGroupId },
+    target: config.sns.auditTopicArn,
+    segregationRef: msgGroupId,
+  });
+
+  await insertMany([outboxEntry], session);
+  logger.info({ outboxEntry }, "Written audit event to outbox.");
+};

--- a/src/grants/subscribers/outbox.subscriber.js
+++ b/src/grants/subscribers/outbox.subscriber.js
@@ -175,9 +175,9 @@ export class OutboxSubscriber {
   // TODO: remove once there are no more standard events
   // temp while we transition to fifo
   topicStringToFifo(topic) {
-    if (topic.search(/_fifo.fifo$/) === -1) {
-      return `${topic}_fifo.fifo`;
-    }
+    //    if (topic.search(/_fifo.fifo$/) === -1) {
+    //      return `${topic}_fifo.fifo`;
+    //    }
 
     return topic;
   }

--- a/src/grants/use-cases/create-status-transition-update.use-case.js
+++ b/src/grants/use-cases/create-status-transition-update.use-case.js
@@ -21,8 +21,6 @@ const writeStatusTransition = async (
     currentStatus,
   });
 
-  throw new Error("Julian Error");
-
   await insertMany(
     [
       new Outbox({

--- a/src/grants/use-cases/create-status-transition-update.use-case.js
+++ b/src/grants/use-cases/create-status-transition-update.use-case.js
@@ -1,8 +1,68 @@
+import {
+  auditActions,
+  auditEntities,
+  buildAuditEvent,
+} from "../../common/audit-constants.js";
 import { config } from "../../common/config.js";
 import { logger } from "../../common/logger.js";
+import { withAudit } from "../../common/with-audit.js";
 import { ApplicationStatusUpdatedEvent } from "../events/application-status-updated.event.js";
 import { Outbox } from "../models/outbox.js";
 import { insertMany } from "../repositories/outbox.repository.js";
+
+const writeStatusTransition = async (
+  { clientRef, code, previousStatus, currentStatus },
+  session,
+) => {
+  const statusEvent = new ApplicationStatusUpdatedEvent({
+    clientRef,
+    code,
+    previousStatus,
+    currentStatus,
+  });
+
+  throw new Error("Julian Error");
+
+  await insertMany(
+    [
+      new Outbox({
+        event: statusEvent,
+        target: config.sns.grantApplicationStatusUpdatedTopicArn,
+        segregationRef: Outbox.getSegregationRef(statusEvent),
+      }),
+    ],
+    session,
+  );
+};
+
+const auditDataBuilder = (args, resultData) => {
+  const [{ clientRef, code, previousStatus, currentStatus }] = args;
+
+  return buildAuditEvent({
+    entity: auditEntities.APPLICATION,
+    action: auditActions.STATUS_TRANSITION,
+    entityid: clientRef,
+    details: { code, fromStatus: previousStatus, toStatus: currentStatus },
+  });
+};
+
+const writeStatusTransitionWithAudit = withAudit(
+  writeStatusTransition,
+  auditDataBuilder,
+);
+
+/* {
+  audit: ({ args }) => {
+    const [{ clientRef, code, previousStatus, currentStatus }] = args;
+    return buildAuditEvent({
+      entity: auditEntities.APPLICATION,
+      action: auditActions.STATUS_TRANSITION,
+      entityid: clientRef,
+      details: { code, fromStatus: previousStatus, toStatus: currentStatus },
+    });
+  },
+  getSession: ({ args }) => args[1],
+}); */
 
 export const createStatusTransitionUpdateUseCase =
   ({
@@ -16,21 +76,13 @@ export const createStatusTransitionUpdateUseCase =
       `Creating status transition update for application ${clientRef} with code ${code}`,
     );
     if (originalFullyQualifiedStatus !== newFullyQualifiedStatus) {
-      const statusEvent = new ApplicationStatusUpdatedEvent({
-        clientRef,
-        code,
-        previousStatus: originalFullyQualifiedStatus,
-        currentStatus: newFullyQualifiedStatus,
-      });
-
-      await insertMany(
-        [
-          new Outbox({
-            event: statusEvent,
-            target: config.sns.grantApplicationStatusUpdatedTopicArn,
-            segregationRef: Outbox.getSegregationRef(statusEvent),
-          }),
-        ],
+      await writeStatusTransitionWithAudit(
+        {
+          clientRef,
+          code,
+          previousStatus: originalFullyQualifiedStatus,
+          currentStatus: newFullyQualifiedStatus,
+        },
         session,
       );
     }

--- a/src/grants/use-cases/replace-application.use-case.js
+++ b/src/grants/use-cases/replace-application.use-case.js
@@ -1,5 +1,11 @@
 import Boom from "@hapi/boom";
+import {
+  auditActions,
+  auditEntities,
+  buildAuditEvent,
+} from "../../common/audit-constants.js";
 import { logger } from "../../common/logger.js";
+import { withAudit } from "../../common/with-audit.js";
 import { withTransaction } from "../../common/with-transaction.js";
 import {
   findByClientRefAndCode,
@@ -9,41 +15,58 @@ import { findByCode } from "../repositories/grant.repository.js";
 import { createApplicationUseCase } from "./create-application.use-case.js";
 import { findApplicationByClientRefAndCodeUseCase } from "./find-application-by-client-ref-and-code.use-case.js";
 
-export const replaceApplicationUseCase = async (code, application) => {
-  logger.info(`Replacing application`);
+const replaceApplication = async ({ code, application }, session) => {
+  const { clientRef, previousClientRef } = application.metadata;
+  logger.info(`Got previousClientRef: ${previousClientRef}.`);
 
-  return withTransaction(async (session) => {
-    const { clientRef, previousClientRef } = application.metadata;
-    logger.info(`Got previousClientRef: ${previousClientRef}.`);
+  const grant = await findByCode(code);
 
-    const grant = await findByCode(code);
+  const previousAppl = await findApplicationByClientRefAndCodeUseCase(
+    previousClientRef,
+    code,
+    session,
+  );
 
-    const previousAppl = await findApplicationByClientRefAndCodeUseCase(
+  if (previousAppl.isReplacementAllowed(grant.amendablePositions)) {
+    logger.info("About to update ApplicationSeries");
+    const applicationID = await createApplicationUseCase(
+      code,
+      application,
+      session,
+    );
+    const series = await findByClientRefAndCode(
       previousClientRef,
       code,
       session,
     );
+    series.addClientRef(clientRef, applicationID);
+    await update(series, session);
+    logger.info("Updated ApplicationSeries.");
+  } else {
+    throw Boom.conflict(
+      `Can not replace existing Application with clientRef: ${previousClientRef} with new clientRef: ${clientRef} - replacement is not allowed`,
+    );
+  }
+  logger.info("End replacing application.");
+};
 
-    if (previousAppl.isReplacementAllowed(grant.amendablePositions)) {
-      logger.info("About to update ApplicationSeries");
-      const applicationID = await createApplicationUseCase(
-        code,
-        application,
-        session,
-      );
-      const series = await findByClientRefAndCode(
-        previousClientRef,
-        code,
-        session,
-      );
-      series.addClientRef(clientRef, applicationID);
-      await update(series, session);
-      logger.info("Updated ApplicationSeries.");
-    } else {
-      throw Boom.conflict(
-        `Can not replace existing Application with clientRef: ${previousClientRef} with new clientRef: ${clientRef} - replacement is not allowed`,
-      );
-    }
-    logger.info("End replacing application.");
+const auditDataBuilder = (args) => {
+  const [{ code, application }] = args;
+  const { clientRef, previousClientRef } = application.metadata;
+  return buildAuditEvent({
+    entity: auditEntities.APPLICATION,
+    action: auditActions.REPLACE_APPLICATION,
+    entityid: clientRef,
+    details: { code, previousClientRef },
   });
 };
+
+const replaceApplicationWithAudit = withAudit(
+  replaceApplication,
+  auditDataBuilder,
+);
+
+export const replaceApplicationUseCase = (code, application) =>
+  withTransaction((session) =>
+    replaceApplicationWithAudit({ code, application }, session),
+  );

--- a/src/grants/use-cases/withdraw-application.use-case.js
+++ b/src/grants/use-cases/withdraw-application.use-case.js
@@ -1,4 +1,10 @@
+import {
+  auditActions,
+  auditEntities,
+  buildAuditEvent,
+} from "../../common/audit-constants.js";
 import { config } from "../../common/config.js";
+import { withAudit } from "../../common/with-audit.js";
 import { UpdateCaseStatusCommand } from "../commands/update-case-status.command.js";
 import { ApplicationStatusUpdatedEvent } from "../events/application-status-updated.event.js";
 import { UpdateAgreementStatusCommand } from "../events/update-agreement-status.command.js";
@@ -10,7 +16,7 @@ import {
 } from "../repositories/application.repository.js";
 import { insertMany } from "../repositories/outbox.repository.js";
 
-export const withdrawApplicationUseCase = async (command, session) => {
+const withdrawApplication = async (command, session) => {
   const { clientRef, code } = command;
   const application = await findByClientRefAndCode(
     { clientRef, code },
@@ -78,3 +84,18 @@ export const withdrawApplicationUseCase = async (command, session) => {
 
   await insertMany(outboxObjects, session);
 };
+
+const auditDataBuilder = (args, resultData) => {
+  const { clientRef, code } = args[0];
+  return buildAuditEvent({
+    entity: auditEntities.APPLICATION,
+    action: auditActions.WITHDRAW_APPLICATION,
+    entityid: clientRef,
+    details: { code },
+  });
+};
+
+export const withdrawApplicationUseCase = withAudit(
+  withdrawApplication,
+  auditDataBuilder,
+);

--- a/src/server.js
+++ b/src/server.js
@@ -9,6 +9,7 @@ import { auth } from "./auth/auth.js";
 import { config } from "./common/config.js";
 import { logger } from "./common/logger.js";
 import { mongoClient } from "./common/mongo-client.js";
+import { withRequestContext } from "./common/request-context.js";
 
 const handlePreResponse = (request, h) => {
   const response = request.response;
@@ -108,6 +109,21 @@ export const createServer = async () => {
     },
     auth,
   ]);
+
+  // eslint-disable-next-line complexity
+  server.ext("onRequest", (request, h) => {
+    const context = {
+      user: request.headers["x-user-id"] ?? null,
+      subject: request.headers["x-subject-id"] ?? null,
+      sessionId: request.headers["x-session-id"] ?? null,
+      ip: request.info.remoteAddress,
+    };
+    for (const cycle of ["_lifecycle", "_postCycle"]) {
+      const fn = request[cycle].bind(request);
+      request[cycle] = () => withRequestContext(context, fn);
+    }
+    return h.continue;
+  });
 
   server.ext("onPreResponse", handlePreResponse);
 

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -45,6 +45,7 @@ export default defineConfig({
       GAS__SNS__GRANT_APPLICATION_STATUS_UPDATED_TOPIC_ARN: "some:arn",
       GAS__SNS__CREATE_NEW_CASE_TOPIC_ARN: "some:arn",
       GAS__SNS__UPDATE_CASE_STATUS_TOPIC_ARN: "some:arn",
+      GAS__SNS__AUDIT_TOPIC_ARN: "some:arn",
     },
   },
 });


### PR DESCRIPTION
The files 
- src/common/audit-constants.js
- src/common/config.js
- src/common/request-context.js
- src/common/sns-client.js
- src/common/write-audit-event.js
- src/grants/subscribers/outbox.subscriber.js
- src/server.js
are the same as previous versions and are supporting code for the main “withAudit” functionality.

The main meat is happening in `src/common/with-audit.js` It has a simpler signature than previous version - making it easier to rationalise. The main difference being we don't need separate paths for transactional/non-transactional... if there is no session, the request is treated as non-transactional.

I’ve chosen 3 use-cases (3 different ways of working) to prove out the code:

**src/grants/use-cases/create-status-transition-update.use-case.js**
- using a conditional audit write inside the use-case

**src/grants/use-cases/replace-application.use-case.js**
- called directly from an api endpoint route with an internal transaction so the auditable code needs extracting before wrapping in with transaction

**src/grants/use-cases/withdraw-application.use-case.js**
- a use-case run as a side effect from a transactional status transition. Possibly the simplest working example.