### PR TITLE
fix(NO-JIRA): Fixing sonar cloud failure, and attempting to fix the pact issue

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,6 +69,9 @@ jobs:
           node-version-file: ".nvmrc"
           cache: npm
 
+      - name: Clear pacts directory
+        run: rm -rf tmp/pacts && mkdir -p tmp/pacts
+
       - name: Run consumer contract tests
         env:
           PACT_BROKER_BASE_URL: https://ffc-pact-broker.azure.defra.cloud

--- a/src/grants/schemas/responses/application-status-response.schema.test.js
+++ b/src/grants/schemas/responses/application-status-response.schema.test.js
@@ -64,7 +64,7 @@ describe("application status response schema", () => {
     );
   });
 
-  it("should throw an error if a response grantCode or clientRef is not valid", async () => {
+  it("should throw an error if a response grantCode is not valid", async () => {
     const response = {
       grantCode: "___)9090sd",
       clientRef: "ref-123",
@@ -80,7 +80,7 @@ describe("application status response schema", () => {
     );
   });
 
-  it("should throw an error if a response grantCode or clientRef is not valid", async () => {
+  it("should throw an error if a response clientRef is not valid", async () => {
     const response = {
       grantCode: "grant-01",
       clientRef: "ref-123_++**&",


### PR DESCRIPTION
Clear the pacts directory before generating consumer pacts on the self-hosted runner, preventing stale pact files from causing a "cannot change content for existing version" error on the pact broker when the pipeline is re-run without a version bump.