### PR TITLE
FGP-1186: FIX omit null members from the audit payload object

### DIFF
--- a/src/common/write-audit-event.js
+++ b/src/common/write-audit-event.js
@@ -14,6 +14,8 @@ const getCorrelationId = () => getTraceId() ?? randomUUID();
 const getUser = (context) => context?.user ?? undefined;
 const getSession = (context) => context?.sessionId ?? undefined;
 const getIP = (context) => context?.ip ?? getServiceIp();
+const stripNulls = (obj) =>
+  Object.fromEntries(Object.entries(obj).filter(([, v]) => v != null));
 const getServiceIp = () => {
   for (const iface of Object.values(networkInterfaces())) {
     const addr = iface.find((n) => n.family === "IPv4" && !n.internal);
@@ -54,13 +56,10 @@ export const writeAuditEvent = async (
   logger.info("Begin write audit event.");
 
   const context = getRequestContext();
-  const payload = buildPayload(context, {
-    entities,
-    accounts,
-    details,
-    security,
-    status,
-  });
+  // mongodb was replacing "undefined" with null which the audit service doesn't like.
+  const payload = stripNulls(
+    buildPayload(context, { entities, accounts, details, security, status }),
+  );
   logger.debug(payload, "audit event payload");
   const { valid, errors } = validateAuditEvent(payload);
   if (valid === false) {

--- a/src/common/write-audit-event.test.js
+++ b/src/common/write-audit-event.test.js
@@ -173,6 +173,16 @@ describe("buildPayload", () => {
     expect(result.sessionid).toBeUndefined();
   });
 
+  it("sets user, sessionid to undefined when context values are null", () => {
+    const result = buildPayload(
+      { user: null, sessionId: null },
+      { entities: [], details: {}, status: auditStatus.SUCCESS },
+    );
+
+    expect(result.user).toBeUndefined();
+    expect(result.sessionid).toBeUndefined();
+  });
+
   it("wraps security when provided", () => {
     const result = buildPayload(null, {
       entities: [],
@@ -273,6 +283,16 @@ describe("writeAuditEvent", () => {
         }),
       }),
     );
+  });
+
+  it("strips null user and sessionid from the payload before validation", async () => {
+    getRequestContext.mockReturnValue({ user: null, sessionId: null });
+
+    await writeAuditEvent(eventData, {});
+
+    const storedEvent = Outbox.mock.calls[0][0].event;
+    expect(storedEvent).not.toHaveProperty("user");
+    expect(storedEvent).not.toHaveProperty("sessionid");
   });
 
   it("skips insertMany when payload fails validation", async () => {

--- a/src/common/write-audit-event.test.js
+++ b/src/common/write-audit-event.test.js
@@ -295,6 +295,27 @@ describe("writeAuditEvent", () => {
     expect(storedEvent).not.toHaveProperty("sessionid");
   });
 
+  it("strips undefined user and sessionid from the payload when context is null", async () => {
+    await writeAuditEvent(eventData, {});
+
+    const storedEvent = Outbox.mock.calls[0][0].event;
+    expect(storedEvent).not.toHaveProperty("user");
+    expect(storedEvent).not.toHaveProperty("sessionid");
+  });
+
+  it("strips undefined user and sessionid from the payload when context values are undefined", async () => {
+    getRequestContext.mockReturnValue({
+      user: undefined,
+      sessionId: undefined,
+    });
+
+    await writeAuditEvent(eventData, {});
+
+    const storedEvent = Outbox.mock.calls[0][0].event;
+    expect(storedEvent).not.toHaveProperty("user");
+    expect(storedEvent).not.toHaveProperty("sessionid");
+  });
+
   it("skips insertMany when payload fails validation", async () => {
     validateAuditEvent.mockReturnValue({
       valid: false,


### PR DESCRIPTION
Fix:

We were validating the payload before committing to the outbox collection.
Audit payload values that were `undefined` validated correctly. However when saving in mongoDB those `undefined` values were converted to `null` and sent as such in the audit payload. It's ok to omit certain values, but not pass them as `null`.
The audit service doesn't validate against `null` values so threw errors when trying to process our messages.
This fix removes `undefined` or `null` values from the payload before we validate it so that when we save and later pull from the db, the payload is unchanged and can be processed by audit service.